### PR TITLE
chore: set snapshot version 0.41.1-SNAPSHOT

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = "io.github.typesafegithub"
-version = "0.41.0"
+version = "0.41.1-SNAPSHOT"
 
 dependencies {
     implementation("org.snakeyaml:snakeyaml-engine:2.6")

--- a/library/src/test/kotlin/io/github/typesafegithub/workflows/docsnippets/GettingStartedSnippets.kt
+++ b/library/src/test/kotlin/io/github/typesafegithub/workflows/docsnippets/GettingStartedSnippets.kt
@@ -18,7 +18,7 @@ class GettingStartedSnippets : FunSpec({
         // --8<-- [start:getting-started-1]
         #!/usr/bin/env kotlin
 
-        @file:DependsOn("io.github.typesafegithub:github-workflows-kt:0.41.0")
+        @file:DependsOn("io.github.typesafegithub:github-workflows-kt:0.41.1-SNAPSHOT")
 
         // --8<-- [end:getting-started-1]
         */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,7 @@ nav:
   - Projects using this library: 'projects-using-this-library.md'
 
 extra:
-  version: 0.41.0
+  version: 0.41.1-SNAPSHOT
 
   # branch or tag name - the script-generator may have not yet updated to a breaking change in the library
   scriptGeneratorVersion: 0.22.0

--- a/script-generator/logic/src/main/kotlin/io/github/typesafegithub/workflows/scriptgenerator/Version.kt
+++ b/script-generator/logic/src/main/kotlin/io/github/typesafegithub/workflows/scriptgenerator/Version.kt
@@ -1,3 +1,3 @@
 package io.github.typesafegithub.workflows.scriptgenerator
 
-val LIBRARY_VERSION = "0.41.0"
+val LIBRARY_VERSION = "0.41.1-SNAPSHOT"


### PR DESCRIPTION
`-SNAPSHOT` will be present in the version on `main` branch, and for releasing we'll remove the suffix.