### PR TITLE
chore(library): do not sign 'SNAPSHOT' versions

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/dsl-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/dsl-publishing.gradle.kts
@@ -60,7 +60,7 @@ publishing {
 }
 
 signing {
-    if (!project.findProperty("suppressSigning")?.toString().toBoolean()) {
+    if (!project.version.toString().endsWith("-SNAPSHOT") && !project.findProperty("suppressSigning")?.toString().toBoolean()) {
         sign(publishing.publications["mavenJava"])
     }
 


### PR DESCRIPTION
It makes it harder to work with them locally.