### PR TITLE
chore: configure .editorconfig to forbid star imports

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_packages_to_use_import_on_demand = unset
+ij_kotlin_name_count_to_use_star_import = 2147483647
+ij_kotlin_name_count_to_use_star_import_for_members = 2147483647


### PR DESCRIPTION
Motivation: https://kotlinlang.slack.com/archives/C02UUATR7RC/p1684128633483979?thread_ts=1684128633.483979&cid=C02UUATR7RC