### PR TITLE
feat(code-generator): remove trailing whitespaces from lines in descriptions

### DIFF
--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/generation/Generation.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/generation/Generation.kt
@@ -170,7 +170,7 @@ private fun TypeSpec.Builder.addOutputClassIfNecessary(metadata: Metadata): Type
     val propertiesFromOutputs = metadata.outputs.map { (key, value) ->
         PropertySpec.builder(key.toCamelCase(), String::class)
             .initializer("\"steps.\$stepId.outputs.$key\"")
-            .addKdoc(value.description.nestedCommentsSanitized)
+            .addKdoc(value.description.nestedCommentsSanitized.removeTrailingWhitespacesForEachLine())
             .build()
     }
     addType(
@@ -315,7 +315,7 @@ private fun Metadata.buildCommonConstructorParameters(
     inputs.map { (key, input) ->
         ParameterSpec.builder(key.toCamelCase(), inputTypings.getInputType(key, input, coords))
             .defaultValueIfNullable(input)
-            .addKdoc(input.description.nestedCommentsSanitized)
+            .addKdoc(input.description.nestedCommentsSanitized.removeTrailingWhitespacesForEachLine())
             .build()
     }.plus(
         ParameterSpec.builder(CUSTOM_INPUTS, Types.mapStringString)
@@ -343,7 +343,7 @@ private fun actionKdoc(metadata: Metadata, coords: ActionCoords) =
     """
        |Action: ${metadata.name.nestedCommentsSanitized}
        |
-       |${metadata.description.nestedCommentsSanitized}
+       |${metadata.description.nestedCommentsSanitized.removeTrailingWhitespacesForEachLine()}
        |
        |[Action on GitHub](https://github.com/${coords.owner}/${coords.name.substringBefore('/')}${if ("/" in coords.name) "/tree/${coords.version}/${coords.name.substringAfter('/')}" else ""})
     """.trimMargin()

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/generation/TextTransformation.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/generation/TextTransformation.kt
@@ -18,3 +18,6 @@ fun String.toPascalCase(): String {
 
 fun String.toCamelCase(): String =
     toPascalCase().replaceFirstChar { it.lowercase() }
+
+fun String.removeTrailingWhitespacesForEachLine(): String =
+    lines().joinToString(separator = "\n") { it.trimEnd() }

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/gradle/GradleBuildActionV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/gradle/GradleBuildActionV2.kt
@@ -44,7 +44,7 @@ public data class GradleBuildActionV2 private constructor(
     public val cacheReadOnly: Boolean? = null,
     /**
      * When 'true', entries will not be restored from the cache but will be saved at the end of the
-     * Job. 
+     * Job.
      * Setting this to 'true' implies cache-read-only will be 'false'.
      */
     public val cacheWriteOnly: Boolean? = null,


### PR DESCRIPTION
They lead to having trailing whitespaces in the Kotlin code, which get removed by ktlint.