### PR TITLE
fix: use @Suppress annotation to disable ktlint rules

### DIFF
--- a/library/src/test/kotlin/io/github/typesafegithub/workflows/docsnippets/GettingStartedSnippets.kt
+++ b/library/src/test/kotlin/io/github/typesafegithub/workflows/docsnippets/GettingStartedSnippets.kt
@@ -1,6 +1,7 @@
+@file:Suppress("ktlint:standard:import-ordering")
+
 package io.github.typesafegithub.workflows.docsnippets
 
-/* ktlint-disable import-ordering */
 import io.kotest.core.spec.style.FunSpec
 // --8<-- [start:getting-started-2]
 import io.github.typesafegithub.workflows.actions.actions.CheckoutV3
@@ -10,7 +11,6 @@ import io.github.typesafegithub.workflows.dsl.workflow
 import io.github.typesafegithub.workflows.yaml.writeToFile
 // --8<-- [end:getting-started-2]
 import java.io.File
-/* ktlint-enable import-ordering */
 
 class GettingStartedSnippets : FunSpec({
     test("gettingStarted") {

--- a/library/src/test/kotlin/io/github/typesafegithub/workflows/yaml/CaseTest.kt
+++ b/library/src/test/kotlin/io/github/typesafegithub/workflows/yaml/CaseTest.kt
@@ -34,5 +34,6 @@ class CaseTest : DescribeSpec({
 })
 
 private enum class MyEnum {
-    In_valid, // ktlint-disable enum-entry-name-case
+    @Suppress("ktlint:standard:enum-entry-name-case")
+    In_valid,
 }


### PR DESCRIPTION
It turned out that in ktlint version 0.50.0, `ktlint-disable` and `ktlint-enable`
are no longer supported. Renovate PR was merged because the CI job where
ktlint runs wasn't set as a required check. It has been fixed in GitHub
configuration, and now this fix is needed.