### PR TITLE
[#941] refactor(automation): rename 'code-generator' to 'wrapper-generator' in wrapper code

### DIFF
--- a/automation/wrapper-generator/src/main/kotlin/io/github/typesafegithub/workflows/wrappergenerator/Generation.kt
+++ b/automation/wrapper-generator/src/main/kotlin/io/github/typesafegithub/workflows/wrappergenerator/Generation.kt
@@ -84,7 +84,7 @@ private fun generateActionWrapperSourceCode(metadata: Metadata, coords: ActionCo
     val fileSpec = FileSpec.builder("io.github.typesafegithub.workflows.actions.${coords.owner.toKotlinPackageName()}", coords.buildActionClassName())
         .addFileComment(
             """
-            This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+            This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
             be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
             generator itself.
             """.trimIndent(),

--- a/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithDeprecatedInputAndNameClashV2.kt
+++ b/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithDeprecatedInputAndNameClashV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithInputsSharingTypeV3.kt
+++ b/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithInputsSharingTypeV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithNoInputsV3.kt
+++ b/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithNoInputsV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithNonStringInputsV3.kt
+++ b/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithNonStringInputsV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithOutputsV3.kt
+++ b/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithOutputsV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithSomeOptionalInputsV3.kt
+++ b/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/ActionWithSomeOptionalInputsV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/DeprecatedActionV2.kt
+++ b/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/DeprecatedActionV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/SimpleActionWithListsV3.kt
+++ b/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/SimpleActionWithListsV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/SimpleActionWithRequiredStringInputsV3.kt
+++ b/automation/wrapper-generator/src/test/kotlin/io/github/typesafegithub/workflows/wrappergenerator/wrappersfromunittests/SimpleActionWithRequiredStringInputsV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/8398a7/ActionSlackV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/8398a7/ActionSlackV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CacheRestoreV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CacheRestoreV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CacheSaveV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CacheSaveV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CacheV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CacheV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CacheV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CacheV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CheckoutV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CheckoutV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CheckoutV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CheckoutV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CheckoutV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CheckoutV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CreateReleaseV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/CreateReleaseV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/DownloadArtifactV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/DownloadArtifactV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/DownloadArtifactV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/DownloadArtifactV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/FirstInteractionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/FirstInteractionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/GithubScriptV6.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/GithubScriptV6.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/LabelerV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/LabelerV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupDotnetV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupDotnetV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupDotnetV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupDotnetV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupGoV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupGoV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupGoV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupGoV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupJavaV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupJavaV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupJavaV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupJavaV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupNodeV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupNodeV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupNodeV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupNodeV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupPythonV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupPythonV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupPythonV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupPythonV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupPythonV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/SetupPythonV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/StaleV5.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/StaleV5.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/StaleV6.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/StaleV6.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/StaleV7.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/StaleV7.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/StaleV8.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/StaleV8.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/UploadArtifactV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/UploadArtifactV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/UploadArtifactV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actions/UploadArtifactV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actionsrs/AuditCheckV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actionsrs/AuditCheckV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actionsrs/CargoV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actionsrs/CargoV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actionsrs/ClippyCheckV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actionsrs/ClippyCheckV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actionsrs/ToolchainV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/actionsrs/ToolchainV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/anmol098/WakaReadmeStatsV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/anmol098/WakaReadmeStatsV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/anothrnick/GithubTagActionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/anothrnick/GithubTagActionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/AmazonEcrLoginV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/AmazonEcrLoginV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/AmazonEcsDeployTaskDefinitionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/AmazonEcsDeployTaskDefinitionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/AmazonEcsRenderTaskDefinitionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/AmazonEcsRenderTaskDefinitionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/ConfigureAwsCredentialsV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/ConfigureAwsCredentialsV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/ConfigureAwsCredentialsV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/ConfigureAwsCredentialsV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/ConfigureAwsCredentialsV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/ConfigureAwsCredentialsV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/ConfigureAwsCredentialsV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/awsactions/ConfigureAwsCredentialsV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/axelop/GooglejavaformatActionV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/axelop/GooglejavaformatActionV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/azure/DockerLoginV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/azure/DockerLoginV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/azure/LoginV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/azure/LoginV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/azure/WebappsDeployV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/azure/WebappsDeployV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/bahmutov/NpmInstallV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/bahmutov/NpmInstallV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/borales/ActionsYarnV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/borales/ActionsYarnV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/borales/ActionsYarnV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/borales/ActionsYarnV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/burrunan/GradleCacheActionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/burrunan/GradleCacheActionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/c2corg/BrowserslistUpdateActionV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/c2corg/BrowserslistUpdateActionV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/c2corg/TransifexPullRequestActionV5.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/c2corg/TransifexPullRequestActionV5.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV17.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV17.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV18.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV18.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV19.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV19.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV20.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV20.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV21.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV21.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV22.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV22.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV23.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cachix/InstallNixActionV23.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/codecov/CodecovActionV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/codecov/CodecovActionV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cycjimmy/SemanticReleaseActionV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cycjimmy/SemanticReleaseActionV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cycjimmy/SemanticReleaseActionV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/cycjimmy/SemanticReleaseActionV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/BuildPushActionV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/BuildPushActionV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/BuildPushActionV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/BuildPushActionV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/BuildPushActionV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/BuildPushActionV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/BuildPushActionV5.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/BuildPushActionV5.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/LoginActionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/LoginActionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/LoginActionV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/LoginActionV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/LoginActionV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/LoginActionV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/MetadataActionV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/MetadataActionV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/MetadataActionV5.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/MetadataActionV5.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/SetupBuildxActionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/SetupBuildxActionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/SetupBuildxActionV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/SetupBuildxActionV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/SetupBuildxActionV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/docker/SetupBuildxActionV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/elgohr/PublishDockerGithubActionV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/elgohr/PublishDockerGithubActionV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/elgohr/PublishDockerGithubActionV5.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/elgohr/PublishDockerGithubActionV5.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/endbug/AddAndCommitV8.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/endbug/AddAndCommitV8.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/endbug/AddAndCommitV9.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/endbug/AddAndCommitV9.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/entrostat/GitSecretActionV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/entrostat/GitSecretActionV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/ericcornelissen/GitTagAnnotationActionV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/ericcornelissen/GitTagAnnotationActionV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/ericcornelissen/SvgoActionV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/ericcornelissen/SvgoActionV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/gautamkrishnar/BlogPostWorkflowV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/gautamkrishnar/BlogPostWorkflowV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/github/CodeqlActionAnalyzeV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/github/CodeqlActionAnalyzeV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/github/CodeqlActionAutobuildV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/github/CodeqlActionAutobuildV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/github/CodeqlActionInitV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/github/CodeqlActionInitV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/github/CodeqlActionUploadSarifV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/github/CodeqlActionUploadSarifV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlecloudplatform/GithubActionsV0.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlecloudplatform/GithubActionsV0.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlecloudplatform/GithubActionsV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlecloudplatform/GithubActionsV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlegithubactions/AuthV0.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlegithubactions/AuthV0.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlegithubactions/AuthV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlegithubactions/AuthV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlegithubactions/SetupGcloudV0.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlegithubactions/SetupGcloudV0.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlegithubactions/SetupGcloudV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/googlegithubactions/SetupGcloudV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/gradle/GradleBuildActionV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/gradle/GradleBuildActionV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/gradle/WrapperValidationActionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/gradle/WrapperValidationActionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/gradleupdate/UpdateGradleWrapperActionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/gradleupdate/UpdateGradleWrapperActionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/jamesives/GithubPagesDeployActionV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/jamesives/GithubPagesDeployActionV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/jasonetco/CreateAnIssueV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/jasonetco/CreateAnIssueV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/juliaactions/SetupJuliaV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/juliaactions/SetupJuliaV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/madhead/CheckGradleVersionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/madhead/CheckGradleVersionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/madhead/IntellijHttpClientActionV0.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/madhead/IntellijHttpClientActionV0.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/madhead/IntellijHttpClientActionV231.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/madhead/IntellijHttpClientActionV231.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/madhead/SemverUtilsV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/madhead/SemverUtilsV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/madhead/SemverUtilsV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/madhead/SemverUtilsV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/microsoft/SetupMsbuildV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/microsoft/SetupMsbuildV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/mikas/KoverReportV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/mikas/KoverReportV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/nobrayner/DiscordWebhookV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/nobrayner/DiscordWebhookV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/peaceiris/ActionsGhPagesV3.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/peaceiris/ActionsGhPagesV3.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/peaceiris/ActionsHugoV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/peaceiris/ActionsHugoV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/peterevans/CreateIssueFromFileV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/peterevans/CreateIssueFromFileV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/peterevans/CreatePullRequestV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/peterevans/CreatePullRequestV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/peterevans/CreatePullRequestV5.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/peterevans/CreatePullRequestV5.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/reactivecircus/AndroidEmulatorRunnerV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/reactivecircus/AndroidEmulatorRunnerV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/reposync/PullRequestV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/reposync/PullRequestV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/ruby/SetupRubyV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/ruby/SetupRubyV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/softprops/ActionGhReleaseV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/softprops/ActionGhReleaseV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/stefanzweifel/GitAutoCommitActionV4.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/stefanzweifel/GitAutoCommitActionV4.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/subosito/FlutterActionV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/subosito/FlutterActionV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/supercharge/MongodbGithubActionV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/supercharge/MongodbGithubActionV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/superfly/FlyctlActionsSetupFlyctlV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/superfly/FlyctlActionsSetupFlyctlV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/typesafegithub/GithubActionsTypingV0.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/typesafegithub/GithubActionsTypingV0.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/typesafegithub/GithubActionsTypingV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/typesafegithub/GithubActionsTypingV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/vampire/SetupWslV1.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/vampire/SetupWslV1.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(

--- a/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/vampire/SetupWslV2.kt
+++ b/library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/vampire/SetupWslV2.kt
@@ -1,4 +1,4 @@
-// This file was generated using 'code-generator' module. Don't change it by hand, your changes will
+// This file was generated using 'wrapper-generator' module. Don't change it by hand, your changes will
 // be overwritten with the next wrapper code regeneration. Instead, consider introducing changes to the
 // generator itself.
 @file:Suppress(


### PR DESCRIPTION
After the recent split from the 'code-generator' module, this adjustment is
needed so that it's clearer which module is responsible for generating the wrappers.