### PR TITLE
[#941] chore(action-binding-generator): enable explicit API mode and dump API

### DIFF
--- a/automation/action-binding-generator/api/action-binding-generator.api
+++ b/automation/action-binding-generator/api/action-binding-generator.api
@@ -1,0 +1,176 @@
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilePath ()Ljava/lang/String;
+	public final fun getKotlinCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/ClassNamingKt {
+	public static final fun buildActionClassName (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;)Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/GenerationKt {
+	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Input {
+	public static final field Companion Lio/github/typesafegithub/workflows/actionbindinggenerator/Input$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Input;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/Input;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Input;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/lang/String;
+	public final fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getRequired ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/actionbindinggenerator/Input;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Input$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/Input$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Input;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/typesafegithub/workflows/actionbindinggenerator/Input;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Input$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/InputNullabilityKt {
+	public static final fun shouldBeNonNullInBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/Input;)Z
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Metadata {
+	public static final field Companion Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getInputs ()Ljava/util/Map;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOutputs ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Metadata$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Metadata$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/MetadataReadingKt {
+	public static final fun actionYamlUrl (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun actionYmlUrl (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun deleteActionYamlCacheIfObsolete ()V
+	public static final fun fetchMetadata (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;
+	public static synthetic fun fetchMetadata$default (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;
+	public static final fun fetchUri (Ljava/net/URI;)Ljava/lang/String;
+	public static final fun getActionYamlDir ()Ljava/io/File;
+	public static final fun getGitHubUrl (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;)Ljava/lang/String;
+	public static final fun getMyYaml ()Lcom/charleskorn/kaml/Yaml;
+	public static final fun getPrettyPrint (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;)Ljava/lang/String;
+	public static final fun getReleasesUrl (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;)Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Output {
+	public static final field Companion Lio/github/typesafegithub/workflows/actionbindinggenerator/Output$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Output;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/Output;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Output;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/actionbindinggenerator/Output;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Output$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/Output$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Output;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/typesafegithub/workflows/actionbindinggenerator/Output;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Output$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Properties {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/Properties;
+	public final fun getCUSTOM_INPUTS ()Ljava/lang/String;
+	public final fun getCUSTOM_VERSION ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/TextTransformationKt {
+	public static final fun removeTrailingWhitespacesForEachLine (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun toCamelCase (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun toKotlinPackageName (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun toPascalCase (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/Types {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/Types;
+	public final fun getListToArray ()Lcom/squareup/kotlinpoet/MemberName;
+	public final fun getMapStringString ()Lcom/squareup/kotlinpoet/ParameterizedTypeName;
+	public final fun getMapToList ()Lcom/squareup/kotlinpoet/MemberName;
+	public final fun getNullableString ()Lcom/squareup/kotlinpoet/TypeName;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/TypingGenerationKt {
+	public static final fun asString (Lio/github/typesafegithub/workflows/actionsmetadata/model/Typing;)Ljava/lang/String;
+	public static final fun buildCustomType (Lio/github/typesafegithub/workflows/actionsmetadata/model/Typing;Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/lang/String;)Lcom/squareup/kotlinpoet/TypeSpec;
+	public static final fun getClassName (Lio/github/typesafegithub/workflows/actionsmetadata/model/Typing;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/kotlinpoet/TypeName;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/TypingSuggestionsKt {
+	public static final fun suggestAdditionalTypings (Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;Ljava/util/Set;)Ljava/lang/String;
+	public static final fun suggestTyping (Lio/github/typesafegithub/workflows/actionbindinggenerator/Input;)Ljava/lang/String;
+}
+

--- a/automation/action-binding-generator/build.gradle.kts
+++ b/automation/action-binding-generator/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     buildsrc.convention.`kotlin-jvm`
 
     kotlin("plugin.serialization")
+
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
 }
 
 dependencies {
@@ -12,6 +14,10 @@ dependencies {
     implementation("com.charleskorn.kaml:kaml:0.55.0")
 
     testImplementation(projects.library)
+}
+
+kotlin {
+    explicitApi()
 }
 
 fun ConfigurableKtLintTask.kotlinterConfig() {

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ClassNaming.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ClassNaming.kt
@@ -3,7 +3,7 @@ package io.github.typesafegithub.workflows.actionbindinggenerator
 import io.github.typesafegithub.workflows.actionsmetadata.model.ActionCoords
 import java.util.Locale
 
-fun ActionCoords.buildActionClassName(): String {
+public fun ActionCoords.buildActionClassName(): String {
     val versionString = version
         .let { if (it.startsWith("v")) it else "v$it" }
         .replaceFirstChar { it.titlecase(Locale.getDefault()) }

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
@@ -8,9 +8,11 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.plusParameter
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
@@ -20,24 +22,24 @@ import io.github.typesafegithub.workflows.actionsmetadata.model.ActionCoords
 import io.github.typesafegithub.workflows.actionsmetadata.model.StringTyping
 import io.github.typesafegithub.workflows.actionsmetadata.model.Typing
 
-data class ActionBinding(
+public data class ActionBinding(
     val kotlinCode: String,
     val filePath: String,
 )
 
-object Types {
-    val mapStringString = Map::class.asTypeName().parameterizedBy(String::class.asTypeName(), String::class.asTypeName())
-    val nullableString = String::class.asTypeName().copy(nullable = true)
-    val mapToList = MemberName("kotlin.collections", "toList")
-    val listToArray = MemberName("kotlin.collections", "toTypedArray")
+public object Types {
+    public val mapStringString: ParameterizedTypeName = Map::class.asTypeName().parameterizedBy(String::class.asTypeName(), String::class.asTypeName())
+    public val nullableString: TypeName = String::class.asTypeName().copy(nullable = true)
+    public val mapToList: MemberName = MemberName("kotlin.collections", "toList")
+    public val listToArray: MemberName = MemberName("kotlin.collections", "toTypedArray")
 }
 
-object Properties {
-    val CUSTOM_INPUTS = "_customInputs"
-    val CUSTOM_VERSION = "_customVersion"
+public object Properties {
+    public val CUSTOM_INPUTS: String = "_customInputs"
+    public val CUSTOM_VERSION: String = "_customVersion"
 }
 
-fun ActionCoords.generateBinding(
+public fun ActionCoords.generateBinding(
     inputTypings: Map<String, Typing> = emptyMap(),
     fetchMetadataImpl: ActionCoords.() -> Metadata = { fetchMetadata() },
 ): ActionBinding {

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/InputNullability.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/InputNullability.kt
@@ -4,5 +4,5 @@ package io.github.typesafegithub.workflows.actionbindinggenerator
  * [Input.required] is in theory a required field in action's metadata, but in practice a lot of actions don't specify
  * it. It's thus a challenge to infer nullability of inputs in the Kotlin bindings. This function tackles this task.
  */
-fun Input.shouldBeNonNullInBinding() =
+public fun Input.shouldBeNonNullInBinding(): Boolean =
     default == null && required == true

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/MetadataReading.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/MetadataReading.kt
@@ -15,7 +15,7 @@ import java.time.LocalDate
  */
 
 @Serializable
-data class Metadata(
+public data class Metadata(
     val name: String,
     val description: String,
     val inputs: Map<String, Input> = emptyMap(),
@@ -23,7 +23,7 @@ data class Metadata(
 )
 
 @Serializable
-data class Input(
+public data class Input(
     val description: String = "",
     val default: String? = null,
     val required: Boolean? = null,
@@ -31,21 +31,21 @@ data class Input(
 )
 
 @Serializable
-data class Output(
+public data class Output(
     val description: String = "",
 )
 
-fun ActionCoords.actionYmlUrl(gitRef: String) = "https://raw.githubusercontent.com/$owner/${name.substringBefore('/')}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yml"
+public fun ActionCoords.actionYmlUrl(gitRef: String): String = "https://raw.githubusercontent.com/$owner/${name.substringBefore('/')}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yml"
 
-fun ActionCoords.actionYamlUrl(gitRef: String) = "https://raw.githubusercontent.com/$owner/${name.substringBefore('/')}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yaml"
+public fun ActionCoords.actionYamlUrl(gitRef: String): String = "https://raw.githubusercontent.com/$owner/${name.substringBefore('/')}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yaml"
 
-val ActionCoords.releasesUrl: String get() = "$gitHubUrl/releases"
+public val ActionCoords.releasesUrl: String get() = "$gitHubUrl/releases"
 
-val ActionCoords.gitHubUrl: String get() = "https://github.com/$owner/$name"
+public val ActionCoords.gitHubUrl: String get() = "https://github.com/$owner/$name"
 
-val ActionCoords.prettyPrint: String get() = "$owner/$name@$version"
+public val ActionCoords.prettyPrint: String get() = "$owner/$name@$version"
 
-fun ActionCoords.fetchMetadata(
+public fun ActionCoords.fetchMetadata(
     commitHash: String = getCommitHashFromFileSystem(),
     useCache: Boolean = true,
     fetchUri: (URI) -> String = ::fetchUri,
@@ -79,17 +79,17 @@ fun ActionCoords.fetchMetadata(
 private fun ActionCoords.getCommitHashFromFileSystem(): String =
     Path.of("actions", owner, name.substringBefore('/'), version, "commit-hash.txt").toFile().readText().trim()
 
-fun fetchUri(uri: URI) = uri.toURL().readText()
+public fun fetchUri(uri: URI): String = uri.toURL().readText()
 
-val myYaml = Yaml(
+public val myYaml: Yaml = Yaml(
     configuration = Yaml.default.configuration.copy(
         strictMode = false,
     ),
 )
 
-val actionYamlDir = File("build/action-yaml")
+public val actionYamlDir: File = File("build/action-yaml")
 
-fun deleteActionYamlCacheIfObsolete() {
+public fun deleteActionYamlCacheIfObsolete() {
     val today = LocalDate.now().toString()
     val dateTxt = actionYamlDir.resolve("date.txt")
     val cacheUpToDate = dateTxt.canRead() && dateTxt.readText() == today

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TextTransformation.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TextTransformation.kt
@@ -2,11 +2,11 @@ package io.github.typesafegithub.workflows.actionbindinggenerator
 
 import java.util.Locale
 
-fun String.toKotlinPackageName() =
+public fun String.toKotlinPackageName(): String =
     replace("-", "")
         .lowercase()
 
-fun String.toPascalCase(): String {
+public fun String.toPascalCase(): String {
     val hasOnlyUppercases = none { it in 'a'..'z' }
     val normalizedString = if (hasOnlyUppercases) lowercase() else this
     return normalizedString.replace("+", "-plus-")
@@ -16,8 +16,8 @@ fun String.toPascalCase(): String {
         }
 }
 
-fun String.toCamelCase(): String =
+public fun String.toCamelCase(): String =
     toPascalCase().replaceFirstChar { it.lowercase() }
 
-fun String.removeTrailingWhitespacesForEachLine(): String =
+public fun String.removeTrailingWhitespacesForEachLine(): String =
     lines().joinToString(separator = "\n") { it.trimEnd() }

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypingGeneration.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypingGeneration.kt
@@ -20,7 +20,7 @@ import io.github.typesafegithub.workflows.actionsmetadata.model.ListOfTypings
 import io.github.typesafegithub.workflows.actionsmetadata.model.StringTyping
 import io.github.typesafegithub.workflows.actionsmetadata.model.Typing
 
-fun Typing.getClassName(actionPackageName: String, actionClassName: String, fieldName: String): TypeName =
+public fun Typing.getClassName(actionPackageName: String, actionClassName: String, fieldName: String): TypeName =
     when (this) {
         BooleanTyping -> Boolean::class.asTypeName()
         is EnumTyping -> {
@@ -38,7 +38,7 @@ fun Typing.getClassName(actionPackageName: String, actionClassName: String, fiel
         StringTyping -> String::class.asTypeName()
     }
 
-fun Typing.asString(): String =
+public fun Typing.asString(): String =
     when (this) {
         BooleanTyping -> ".toString()"
         is EnumTyping -> ".stringValue"
@@ -58,7 +58,7 @@ fun Typing.asString(): String =
         else -> ""
     }
 
-fun Typing.buildCustomType(coords: ActionCoords, fieldName: String): TypeSpec? =
+public fun Typing.buildCustomType(coords: ActionCoords, fieldName: String): TypeSpec? =
     when (this) {
         is EnumTyping -> buildEnumCustomType(coords, fieldName)
         is IntegerWithSpecialValueTyping -> buildIntegerWithSpecialValueCustomType(coords, fieldName)

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypingSuggestions.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypingSuggestions.kt
@@ -1,6 +1,6 @@
 package io.github.typesafegithub.workflows.actionbindinggenerator
 
-fun Metadata.suggestAdditionalTypings(existingTypings: Set<String>): String? {
+public fun Metadata.suggestAdditionalTypings(existingTypings: Set<String>): String? {
     val keys = (inputs.keys - existingTypings).associate {
         it to inputs.get(it)!!
     }
@@ -21,7 +21,7 @@ fun Metadata.suggestAdditionalTypings(existingTypings: Set<String>): String? {
     }
 }
 
-fun Input.suggestTyping(): String? {
+public fun Input.suggestTyping(): String? {
     val listKeywords = setOf(
         "list of",
         "paths",


### PR DESCRIPTION
The goal is to help polish the API so that no internally used stuff is exposed there,
only things strictly needed for bindings generation.