### PR TITLE
[#941] refactor(abg): hide trivial cases of impl details

### DIFF
--- a/automation/action-binding-generator/api/action-binding-generator.api
+++ b/automation/action-binding-generator/api/action-binding-generator.api
@@ -57,10 +57,6 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/Inp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/typesafegithub/workflows/actionbindinggenerator/InputNullabilityKt {
-	public static final fun shouldBeNonNullInBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/Input;)Z
-}
-
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/Metadata {
 	public static final field Companion Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata$Companion;
 	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
@@ -98,15 +94,12 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/Met
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/MetadataReadingKt {
-	public static final fun actionYamlUrl (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/lang/String;)Ljava/lang/String;
-	public static final fun actionYmlUrl (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun deleteActionYamlCacheIfObsolete ()V
 	public static final fun fetchMetadata (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;
 	public static synthetic fun fetchMetadata$default (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;
 	public static final fun fetchUri (Ljava/net/URI;)Ljava/lang/String;
 	public static final fun getActionYamlDir ()Ljava/io/File;
 	public static final fun getGitHubUrl (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;)Ljava/lang/String;
-	public static final fun getMyYaml ()Lcom/charleskorn/kaml/Yaml;
 	public static final fun getPrettyPrint (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;)Ljava/lang/String;
 	public static final fun getReleasesUrl (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;)Ljava/lang/String;
 }
@@ -142,35 +135,8 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/Out
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/typesafegithub/workflows/actionbindinggenerator/Properties {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/Properties;
-	public final fun getCUSTOM_INPUTS ()Ljava/lang/String;
-	public final fun getCUSTOM_VERSION ()Ljava/lang/String;
-}
-
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/TextTransformationKt {
-	public static final fun removeTrailingWhitespacesForEachLine (Ljava/lang/String;)Ljava/lang/String;
-	public static final fun toCamelCase (Ljava/lang/String;)Ljava/lang/String;
 	public static final fun toKotlinPackageName (Ljava/lang/String;)Ljava/lang/String;
 	public static final fun toPascalCase (Ljava/lang/String;)Ljava/lang/String;
-}
-
-public final class io/github/typesafegithub/workflows/actionbindinggenerator/Types {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/Types;
-	public final fun getListToArray ()Lcom/squareup/kotlinpoet/MemberName;
-	public final fun getMapStringString ()Lcom/squareup/kotlinpoet/ParameterizedTypeName;
-	public final fun getMapToList ()Lcom/squareup/kotlinpoet/MemberName;
-	public final fun getNullableString ()Lcom/squareup/kotlinpoet/TypeName;
-}
-
-public final class io/github/typesafegithub/workflows/actionbindinggenerator/TypingGenerationKt {
-	public static final fun asString (Lio/github/typesafegithub/workflows/actionsmetadata/model/Typing;)Ljava/lang/String;
-	public static final fun buildCustomType (Lio/github/typesafegithub/workflows/actionsmetadata/model/Typing;Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/lang/String;)Lcom/squareup/kotlinpoet/TypeSpec;
-	public static final fun getClassName (Lio/github/typesafegithub/workflows/actionsmetadata/model/Typing;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/kotlinpoet/TypeName;
-}
-
-public final class io/github/typesafegithub/workflows/actionbindinggenerator/TypingSuggestionsKt {
-	public static final fun suggestAdditionalTypings (Lio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;Ljava/util/Set;)Ljava/lang/String;
-	public static final fun suggestTyping (Lio/github/typesafegithub/workflows/actionbindinggenerator/Input;)Ljava/lang/String;
 }
 

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
@@ -8,11 +8,9 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
-import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.plusParameter
 import com.squareup.kotlinpoet.PropertySpec
-import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
@@ -27,16 +25,16 @@ public data class ActionBinding(
     val filePath: String,
 )
 
-public object Types {
-    public val mapStringString: ParameterizedTypeName = Map::class.asTypeName().parameterizedBy(String::class.asTypeName(), String::class.asTypeName())
-    public val nullableString: TypeName = String::class.asTypeName().copy(nullable = true)
-    public val mapToList: MemberName = MemberName("kotlin.collections", "toList")
-    public val listToArray: MemberName = MemberName("kotlin.collections", "toTypedArray")
+private object Types {
+    val mapStringString = Map::class.asTypeName().parameterizedBy(String::class.asTypeName(), String::class.asTypeName())
+    val nullableString = String::class.asTypeName().copy(nullable = true)
+    val mapToList = MemberName("kotlin.collections", "toList")
+    val listToArray = MemberName("kotlin.collections", "toTypedArray")
 }
 
-public object Properties {
-    public val CUSTOM_INPUTS: String = "_customInputs"
-    public val CUSTOM_VERSION: String = "_customVersion"
+private object Properties {
+    val CUSTOM_INPUTS = "_customInputs"
+    val CUSTOM_VERSION = "_customVersion"
 }
 
 public fun ActionCoords.generateBinding(

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/InputNullability.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/InputNullability.kt
@@ -4,5 +4,5 @@ package io.github.typesafegithub.workflows.actionbindinggenerator
  * [Input.required] is in theory a required field in action's metadata, but in practice a lot of actions don't specify
  * it. It's thus a challenge to infer nullability of inputs in the Kotlin bindings. This function tackles this task.
  */
-public fun Input.shouldBeNonNullInBinding(): Boolean =
+internal fun Input.shouldBeNonNullInBinding() =
     default == null && required == true

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/MetadataReading.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/MetadataReading.kt
@@ -35,9 +35,9 @@ public data class Output(
     val description: String = "",
 )
 
-public fun ActionCoords.actionYmlUrl(gitRef: String): String = "https://raw.githubusercontent.com/$owner/${name.substringBefore('/')}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yml"
+private fun ActionCoords.actionYmlUrl(gitRef: String) = "https://raw.githubusercontent.com/$owner/${name.substringBefore('/')}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yml"
 
-public fun ActionCoords.actionYamlUrl(gitRef: String): String = "https://raw.githubusercontent.com/$owner/${name.substringBefore('/')}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yaml"
+private fun ActionCoords.actionYamlUrl(gitRef: String) = "https://raw.githubusercontent.com/$owner/${name.substringBefore('/')}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yaml"
 
 public val ActionCoords.releasesUrl: String get() = "$gitHubUrl/releases"
 
@@ -81,7 +81,7 @@ private fun ActionCoords.getCommitHashFromFileSystem(): String =
 
 public fun fetchUri(uri: URI): String = uri.toURL().readText()
 
-public val myYaml: Yaml = Yaml(
+private val myYaml = Yaml(
     configuration = Yaml.default.configuration.copy(
         strictMode = false,
     ),

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TextTransformation.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TextTransformation.kt
@@ -16,8 +16,8 @@ public fun String.toPascalCase(): String {
         }
 }
 
-public fun String.toCamelCase(): String =
+internal fun String.toCamelCase() =
     toPascalCase().replaceFirstChar { it.lowercase() }
 
-public fun String.removeTrailingWhitespacesForEachLine(): String =
+internal fun String.removeTrailingWhitespacesForEachLine() =
     lines().joinToString(separator = "\n") { it.trimEnd() }

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypingGeneration.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypingGeneration.kt
@@ -20,7 +20,7 @@ import io.github.typesafegithub.workflows.actionsmetadata.model.ListOfTypings
 import io.github.typesafegithub.workflows.actionsmetadata.model.StringTyping
 import io.github.typesafegithub.workflows.actionsmetadata.model.Typing
 
-public fun Typing.getClassName(actionPackageName: String, actionClassName: String, fieldName: String): TypeName =
+internal fun Typing.getClassName(actionPackageName: String, actionClassName: String, fieldName: String): TypeName =
     when (this) {
         BooleanTyping -> Boolean::class.asTypeName()
         is EnumTyping -> {
@@ -38,7 +38,7 @@ public fun Typing.getClassName(actionPackageName: String, actionClassName: Strin
         StringTyping -> String::class.asTypeName()
     }
 
-public fun Typing.asString(): String =
+internal fun Typing.asString(): String =
     when (this) {
         BooleanTyping -> ".toString()"
         is EnumTyping -> ".stringValue"
@@ -58,7 +58,7 @@ public fun Typing.asString(): String =
         else -> ""
     }
 
-public fun Typing.buildCustomType(coords: ActionCoords, fieldName: String): TypeSpec? =
+internal fun Typing.buildCustomType(coords: ActionCoords, fieldName: String): TypeSpec? =
     when (this) {
         is EnumTyping -> buildEnumCustomType(coords, fieldName)
         is IntegerWithSpecialValueTyping -> buildIntegerWithSpecialValueCustomType(coords, fieldName)

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypingSuggestions.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypingSuggestions.kt
@@ -1,6 +1,6 @@
 package io.github.typesafegithub.workflows.actionbindinggenerator
 
-public fun Metadata.suggestAdditionalTypings(existingTypings: Set<String>): String? {
+internal fun Metadata.suggestAdditionalTypings(existingTypings: Set<String>): String? {
     val keys = (inputs.keys - existingTypings).associate {
         it to inputs.get(it)!!
     }
@@ -21,7 +21,7 @@ public fun Metadata.suggestAdditionalTypings(existingTypings: Set<String>): Stri
     }
 }
 
-public fun Input.suggestTyping(): String? {
+internal fun Input.suggestTyping(): String? {
     val listKeywords = setOf(
         "list of",
         "paths",

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/types/TypesProviding.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/types/TypesProviding.kt
@@ -2,7 +2,6 @@ package io.github.typesafegithub.workflows.codegenerator.types
 
 import com.charleskorn.kaml.Yaml
 import io.github.typesafegithub.workflows.actionbindinggenerator.fetchUri
-import io.github.typesafegithub.workflows.actionbindinggenerator.myYaml
 import io.github.typesafegithub.workflows.actionbindinggenerator.prettyPrint
 import io.github.typesafegithub.workflows.actionbindinggenerator.releasesUrl
 import io.github.typesafegithub.workflows.actionbindinggenerator.toPascalCase
@@ -123,3 +122,9 @@ private inline fun <reified T> Yaml.decodeFromStringOrDefaultIfEmpty(text: Strin
     } else {
         default
     }
+
+private val myYaml = Yaml(
+    configuration = Yaml.default.configuration.copy(
+        strictMode = false,
+    ),
+)


### PR DESCRIPTION
This is the first step of making the API of action-binding-generator minimal. Some functions/classes are simply used just in this module, so can be made internal/private. The rest are unfortunately depended on from other modules, so these dependencies will need more effort to be sorted out.