### PR TITLE
[#941] refactor(automation): include class name in binding object

### DIFF
--- a/automation/action-binding-generator/api/action-binding-generator.api
+++ b/automation/action-binding-generator/api/action-binding-generator.api
@@ -1,18 +1,16 @@
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassName ()Ljava/lang/String;
 	public final fun getFilePath ()Ljava/lang/String;
 	public final fun getKotlinCode ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/github/typesafegithub/workflows/actionbindinggenerator/ClassNamingKt {
-	public static final fun buildActionClassName (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;)Ljava/lang/String;
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/GenerationKt {

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ClassNaming.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ClassNaming.kt
@@ -3,7 +3,7 @@ package io.github.typesafegithub.workflows.actionbindinggenerator
 import io.github.typesafegithub.workflows.actionsmetadata.model.ActionCoords
 import java.util.Locale
 
-public fun ActionCoords.buildActionClassName(): String {
+internal fun ActionCoords.buildActionClassName(): String {
     val versionString = version
         .let { if (it.startsWith("v")) it else "v$it" }
         .replaceFirstChar { it.titlecase(Locale.getDefault()) }

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
@@ -27,6 +27,7 @@ import io.github.typesafegithub.workflows.metadatareading.prettyPrint
 public data class ActionBinding(
     val kotlinCode: String,
     val filePath: String,
+    val className: String,
 )
 
 private object Types {
@@ -56,9 +57,11 @@ public fun ActionCoords.generateBinding(
     }
 
     val actionBindingSourceCode = generateActionBindingSourceCode(metadata, this, inputTypings)
+    val className = this.buildActionClassName()
     return ActionBinding(
         kotlinCode = actionBindingSourceCode,
-        filePath = "library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/${owner.toKotlinPackageName()}/${this.buildActionClassName()}.kt",
+        filePath = "library/src/gen/kotlin/io/github/typesafegithub/workflows/actions/${owner.toKotlinPackageName()}/$className.kt",
+        className = className,
     )
 }
 


### PR DESCRIPTION
Thanks to this, the action binding generator doesn't have to expose a function that generates the class name - it's provided as a part of the generated binding object.