### PR TITLE
test(library): fix adding extra resources

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -45,9 +45,7 @@ tasks.withType<KotlinCompile> {
 
 tasks.test {
     // The integration tests read from and write to there.
-    val githubWorkflowsDir = "$rootDir/.github/workflows"
-    inputs.dir(githubWorkflowsDir)
-    outputs.dir(githubWorkflowsDir)
+    inputs.dir("$rootDir/.github/workflows")
 }
 
 kotlin {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -33,12 +33,6 @@ sourceSets {
             setSrcDirs(listOf("src/gen/kotlin"))
         }
     }
-    test {
-        resources {
-            // The integration tests read from and write to there.
-            setSrcDirs(listOf("$rootDir/.github/workflows"))
-        }
-    }
 }
 
 tasks.withType<KotlinCompile> {
@@ -47,6 +41,13 @@ tasks.withType<KotlinCompile> {
             "-opt-in=io.github.typesafegithub.workflows.internal.InternalGithubActionsApi",
         )
     }
+}
+
+tasks.test {
+    // The integration tests read from and write to there.
+    val githubWorkflowsDir = "$rootDir/.github/workflows"
+    inputs.dir(githubWorkflowsDir)
+    outputs.dir(githubWorkflowsDir)
 }
 
 kotlin {


### PR DESCRIPTION
This way is the correct one to tell Gradle that other resources (outside of the standard `resources` dir) are used as inputs and outputs. In fact, it's only about `.github/workflows/Integration tests - *.yaml`, but for simplicity we mark the whole directory.