### PR TITLE
[#941] refactor: move typing resolving to abg

### DIFF
--- a/automation/action-binding-generator/api/action-binding-generator.api
+++ b/automation/action-binding-generator/api/action-binding-generator.api
@@ -16,7 +16,11 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/Act
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/GenerationKt {
-	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
-	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/util/Map;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionsmetadata/model/ActionCoords;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/TypesProvidingKt {
+	public static final fun deleteActionTypesYamlCacheIfObsolete ()V
 }
 

--- a/automation/action-binding-generator/build.gradle.kts
+++ b/automation/action-binding-generator/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(projects.automation.metadataReading)
     implementation(projects.automation.textUtils)
     implementation("com.squareup:kotlinpoet:1.14.2")
+    implementation("com.charleskorn.kaml:kaml:0.55.0")
 
     testImplementation(projects.library)
 }

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
@@ -84,11 +84,12 @@ internal fun getCommitHash(actionCoords: ActionCoords): String? =
 internal fun getLocalTypings(actionCoords: ActionCoords): String? {
     val pathBeforeVersion = Path.of("actions", actionCoords.owner, actionCoords.name.split("/").first(), actionCoords.version)
     val subnames = actionCoords.name.split("/").drop(1).joinToString("/")
-    val fullPath = if (subnames.isNotEmpty()) {
-        pathBeforeVersion.resolve(subnames).resolve("action-types.yml")
-    } else {
-        pathBeforeVersion.resolve("action-types.yml")
-    }
+    val fullPath =
+        if (subnames.isNotEmpty()) {
+            pathBeforeVersion.resolve(subnames).resolve("action-types.yml")
+        } else {
+            pathBeforeVersion.resolve("action-types.yml")
+        }
     return fullPath.toFile().let {
         if (it.exists()) it.readText() else null
     }
@@ -140,7 +141,7 @@ private inline fun <reified T> Yaml.decodeFromStringOrDefaultIfEmpty(
 private val myYaml =
     Yaml(
         configuration =
-        Yaml.default.configuration.copy(
-            strictMode = false,
-        ),
+            Yaml.default.configuration.copy(
+                strictMode = false,
+            ),
     )

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
@@ -14,8 +14,6 @@ import io.github.typesafegithub.workflows.actionsmetadata.model.ListOfTypings
 import io.github.typesafegithub.workflows.actionsmetadata.model.StringTyping
 import io.github.typesafegithub.workflows.actionsmetadata.model.Typing
 import io.github.typesafegithub.workflows.metadatareading.fetchUri
-import io.github.typesafegithub.workflows.metadatareading.prettyPrint
-import io.github.typesafegithub.workflows.metadatareading.releasesUrl
 import io.github.typesafegithub.workflows.textutils.toPascalCase
 import kotlinx.serialization.decodeFromString
 import java.io.File
@@ -70,10 +68,7 @@ private fun ActionCoords.fetchTypingMetadata(
             } catch (e: IOException) {
                 null
             }
-        } ?: error(
-            "$prettyPrint\n†Can't fetch any of those URLs:\n- ${list.joinToString(separator = "\n- ")}\n" +
-                "Check release page $releasesUrl",
-        )
+        } ?: return null
 
     cacheFile.parentFile.mkdirs()
     cacheFile.writeText(typesMetadataYaml)

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
@@ -81,11 +81,18 @@ internal fun getCommitHash(actionCoords: ActionCoords): String? =
             if (it.exists()) it.readText().trim() else null
         }
 
-internal fun getLocalTypings(actionCoords: ActionCoords): String? =
-    Path.of("actions", actionCoords.owner, actionCoords.name, actionCoords.version, "action-types.yml")
-        .toFile().let {
-            if (it.exists()) it.readText() else null
-        }
+internal fun getLocalTypings(actionCoords: ActionCoords): String? {
+    val pathBeforeVersion = Path.of("actions", actionCoords.owner, actionCoords.name.split("/").first(), actionCoords.version)
+    val subnames = actionCoords.name.split("/").drop(1).joinToString("/")
+    val fullPath = if (subnames.isNotEmpty()) {
+        pathBeforeVersion.resolve(subnames).resolve("action-types.yml")
+    } else {
+        pathBeforeVersion.resolve("action-types.yml")
+    }
+    return fullPath.toFile().let {
+        if (it.exists()) it.readText() else null
+    }
+}
 
 internal fun ActionTypes.toTypesMap(): Map<String, Typing> {
     return inputs.mapValues { (key, value) ->
@@ -133,7 +140,7 @@ private inline fun <reified T> Yaml.decodeFromStringOrDefaultIfEmpty(
 private val myYaml =
     Yaml(
         configuration =
-            Yaml.default.configuration.copy(
-                strictMode = false,
-            ),
+        Yaml.default.configuration.copy(
+            strictMode = false,
+        ),
     )

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GenerationTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GenerationTest.kt
@@ -50,7 +50,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "simple-action-with-required-string-inputs", "v3")
 
         // when
-        val binding = coords.generateBinding { actionManifest }
+        val binding = coords.generateBinding(fetchMetadataImpl = { actionManifest })
 
         // then
         binding.shouldMatchFile("SimpleActionWithRequiredStringInputsV3.kt")
@@ -212,7 +212,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "action-with-outputs", "v3")
 
         // when
-        val binding = coords.generateBinding { actionManifest }
+        val binding = coords.generateBinding(fetchMetadataImpl = { actionManifest })
 
         // then
         binding.shouldMatchFile("ActionWithOutputsV3.kt")
@@ -241,7 +241,7 @@ class GenerationTest : FunSpec({
 
         shouldThrowAny {
             // when
-            coords.generateBinding(inputTypings) { actionManifest }
+            coords.generateBinding(fetchMetadataImpl = { actionManifest }, inputTypings = inputTypings)
         }.shouldHaveMessage(
             // then
             """
@@ -265,7 +265,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "action-with-no-inputs", "v3")
 
         // when
-        val binding = coords.generateBinding { actionManifest }
+        val binding = coords.generateBinding(fetchMetadataImpl = { actionManifest })
 
         // then
         binding.shouldMatchFile("ActionWithNoInputsV3.kt")
@@ -284,7 +284,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "deprecated-action", "v2", deprecatedByVersion = "v3")
 
         // when
-        val binding = coords.generateBinding { actionManifest }
+        val binding = coords.generateBinding(fetchMetadataImpl = { actionManifest })
 
         // then
         binding.shouldMatchFile("DeprecatedActionV2.kt")
@@ -317,7 +317,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "action-with-deprecated-input-and-name-clash", "v2")
 
         // when
-        val binding = coords.generateBinding { actionManifest }
+        val binding = coords.generateBinding(fetchMetadataImpl = { actionManifest })
 
         // then
         binding.shouldMatchFile("ActionWithDeprecatedInputAndNameClashV2.kt")
@@ -355,7 +355,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "simple-action-with-lists", "v3")
 
         // when
-        val binding = coords.generateBinding(inputTypings) { actionManifest }
+        val binding = coords.generateBinding(fetchMetadataImpl = { actionManifest }, inputTypings = inputTypings)
 
         // then
         binding.shouldMatchFile("SimpleActionWithListsV3.kt")

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProvidingTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProvidingTest.kt
@@ -1,6 +1,5 @@
-package io.github.typesafegithub.workflows.codegenerator.types
+package io.github.typesafegithub.workflows.actionbindinggenerator
 
-import io.github.typesafegithub.workflows.actionsmetadata.model.ActionBindingRequest
 import io.github.typesafegithub.workflows.actionsmetadata.model.ActionCoords
 import io.github.typesafegithub.workflows.actionsmetadata.model.BooleanTyping
 import io.github.typesafegithub.workflows.actionsmetadata.model.EnumTyping
@@ -9,7 +8,6 @@ import io.github.typesafegithub.workflows.actionsmetadata.model.IntegerTyping
 import io.github.typesafegithub.workflows.actionsmetadata.model.IntegerWithSpecialValueTyping
 import io.github.typesafegithub.workflows.actionsmetadata.model.ListOfTypings
 import io.github.typesafegithub.workflows.actionsmetadata.model.StringTyping
-import io.github.typesafegithub.workflows.actionsmetadata.model.TypingsSource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -51,14 +49,10 @@ class TypesProvidingTest : FunSpec({
                   - admin
                   - guest
             """.trimIndent()
-        val actionBindingRequest =
-            ActionBindingRequest(
-                actionCoords = ActionCoords("some-owner", "some-name", "v1"),
-                typingsSource = TypingsSource.ActionTypes,
-            )
+        val actionCoord = ActionCoords("some-owner", "some-name", "v1")
 
         // When
-        val types = actionBindingRequest.provideTypes({ actionTypesYml }, { "some-hash" })
+        val types = actionCoord.provideTypes({ actionTypesYml }, { "some-hash" })
 
         // Then
         types shouldBe

--- a/automation/code-generator/build.gradle.kts
+++ b/automation/code-generator/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 }
 
 dependencies {
-    implementation("com.charleskorn.kaml:kaml:0.55.0")
     implementation("com.squareup:kotlinpoet:1.14.2")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
 

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/GenerationEntryPoint.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/GenerationEntryPoint.kt
@@ -1,14 +1,13 @@
 package io.github.typesafegithub.workflows.codegenerator
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionBinding
+import io.github.typesafegithub.workflows.actionbindinggenerator.deleteActionTypesYamlCacheIfObsolete
 import io.github.typesafegithub.workflows.actionbindinggenerator.generateBinding
 import io.github.typesafegithub.workflows.actionsmetadata.bindingsToGenerate
 import io.github.typesafegithub.workflows.actionsmetadata.model.ActionBindingRequest
 import io.github.typesafegithub.workflows.actionsmetadata.model.ActionCoords
 import io.github.typesafegithub.workflows.actionsmetadata.model.TypingsSource
 import io.github.typesafegithub.workflows.actionsmetadata.model.Version
-import io.github.typesafegithub.workflows.codegenerator.types.deleteActionTypesYamlCacheIfObsolete
-import io.github.typesafegithub.workflows.codegenerator.types.provideTypes
 import io.github.typesafegithub.workflows.dsl.expressions.generateEventPayloads
 import io.github.typesafegithub.workflows.metadatareading.deleteActionYamlCacheIfObsolete
 import io.github.typesafegithub.workflows.metadatareading.prettyPrint
@@ -36,8 +35,7 @@ private fun generateBindings(): List<Pair<ActionBindingRequest, ActionBinding>> 
     val requestsAndBindings =
         bindingsToGenerate.map { actionBindingRequest ->
             println("Generating ${actionBindingRequest.actionCoords.prettyPrint}")
-            val inputTypings = actionBindingRequest.provideTypes()
-            val binding = actionBindingRequest.actionCoords.generateBinding(inputTypings)
+            val binding = actionBindingRequest.actionCoords.generateBinding()
             Pair(actionBindingRequest, binding)
         }
     requestsAndBindings.forEach { (_, binding) ->

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/updating/CreateActionUpdatePRs.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/updating/CreateActionUpdatePRs.kt
@@ -6,7 +6,6 @@ import io.github.typesafegithub.workflows.actionsmetadata.bindingsToGenerate
 import io.github.typesafegithub.workflows.actionsmetadata.model.ActionBindingRequest
 import io.github.typesafegithub.workflows.actionsmetadata.model.ActionCoords
 import io.github.typesafegithub.workflows.actionsmetadata.model.isTopLevel
-import io.github.typesafegithub.workflows.codegenerator.types.provideTypes
 import io.github.typesafegithub.workflows.codegenerator.versions.GithubRef
 import io.github.typesafegithub.workflows.codegenerator.versions.GithubTag
 import io.github.typesafegithub.workflows.codegenerator.versions.getGithubToken
@@ -81,7 +80,7 @@ private suspend fun createPullRequest(
 
 private fun ActionBindingRequest.generateBindingForCommit(commitHash: String): ActionBinding =
     actionCoords.generateBinding(
-        inputTypings = provideTypes(getCommitHash = { commitHash }),
+        commitHash = commitHash,
         fetchMetadataImpl = { fetchMetadata(commitHash = commitHash, useCache = false) },
     )
 


### PR DESCRIPTION
It's a step towards having the bindings generation process encapsulated within a single module: action-bindings-generator. Code-generator shouldn't be aware of this implementation detail.