### PR TITLE
[#774] chore: remove JitPack support

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/action-binding-generator-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/action-binding-generator-publishing.gradle.kts
@@ -64,7 +64,7 @@ publishing {
 }
 
 signing {
-    if (!project.version.toString().endsWith("-SNAPSHOT") && !project.findProperty("suppressSigning")?.toString().toBoolean()) {
+    if (!project.version.toString().endsWith("-SNAPSHOT")) {
         sign(publishing.publications["mavenJava"])
     }
 

--- a/buildSrc/src/main/kotlin/buildsrc/convention/dsl-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/dsl-publishing.gradle.kts
@@ -64,7 +64,7 @@ publishing {
 }
 
 signing {
-    if (!project.version.toString().endsWith("-SNAPSHOT") && !project.findProperty("suppressSigning")?.toString().toBoolean()) {
+    if (!project.version.toString().endsWith("-SNAPSHOT")) {
         sign(publishing.publications["mavenJava"])
     }
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,0 @@
-before_install:
-  - sdk install java 17.0.4.1-zulu
-  - sdk use java 17.0.4.1-zulu
-install:
-  - echo "Running a custom install command"
-  - ./gradlew clean :library:publishToMavenLocal -x test -P suppressSigning=true


### PR DESCRIPTION
Now that we publish more than one artifact from this repo, JitPack is not suitable anymore. Instead, we publish Sonatype snapshots on each commit to main, and for feature branches, we can do it as well after a small code modification.