### PR TITLE
[#941] refactor(abg): enhance passing metadata revision

### DIFF
--- a/automation/action-binding-generator/api/action-binding-generator.api
+++ b/automation/action-binding-generator/api/action-binding-generator.api
@@ -38,9 +38,27 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/Act
 	public static final fun isTopLevel (Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionCoords;)Z
 }
 
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/CommitHash : io/github/typesafegithub/workflows/actionbindinggenerator/MetadataRevision {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/actionbindinggenerator/CommitHash;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/CommitHash;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/CommitHash;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/FromLockfile : io/github/typesafegithub/workflows/actionbindinggenerator/MetadataRevision {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/FromLockfile;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/GenerationKt {
-	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionCoords;Ljava/lang/String;ZLio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;Ljava/util/Map;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
-	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionCoords;Ljava/lang/String;ZLio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/MetadataRevision;ZLio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;Ljava/util/Map;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
+	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/MetadataRevision;ZLio/github/typesafegithub/workflows/actionbindinggenerator/Metadata;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/ActionBinding;
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/Input {
@@ -118,6 +136,16 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/Met
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/MetadataReadingKt {
 	public static final fun deleteActionYamlCacheIfObsolete ()V
+}
+
+public abstract interface class io/github/typesafegithub/workflows/actionbindinggenerator/MetadataRevision {
+}
+
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/NewestForVersion : io/github/typesafegithub/workflows/actionbindinggenerator/MetadataRevision {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/NewestForVersion;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/Output {

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
@@ -38,13 +38,10 @@ private object Properties {
 }
 
 public fun ActionCoords.generateBinding(
-    commitHash: String? = getCommitHashFromFileSystem(),
+    metadataRevision: MetadataRevision,
     useCache: Boolean = true,
-    metadata: Metadata =
-        commitHash?.let {
-            this.fetchMetadata(commitHash = it, useCache = useCache)
-        } ?: this.fetchMetadata(useCache = useCache),
-    inputTypings: Map<String, Typing> = provideTypes(getCommitHash = { commitHash }),
+    metadata: Metadata = this.fetchMetadata(metadataRevision, useCache = useCache),
+    inputTypings: Map<String, Typing> = provideTypes(metadataRevision),
 ): ActionBinding {
     require(this.version.removePrefix("v").toIntOrNull() != null) {
         "Only major versions are supported, and '${this.version}' was given!"

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/MetadataReading.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/MetadataReading.kt
@@ -49,7 +49,7 @@ internal val ActionCoords.releasesUrl: String get() = "$gitHubUrl/releases"
 internal val ActionCoords.gitHubUrl: String get() = "https://github.com/$owner/$name"
 
 internal fun ActionCoords.fetchMetadata(
-    commitHash: String = getCommitHashFromFileSystem(),
+    metadataRevision: MetadataRevision,
     useCache: Boolean = true,
     fetchUri: (URI) -> String = ::fetchUri,
 ): Metadata {
@@ -61,7 +61,13 @@ internal fun ActionCoords.fetchMetadata(
         }
     }
 
-    val list = listOf(actionYmlUrl(commitHash), actionYamlUrl(commitHash))
+    val gitRef =
+        when (metadataRevision) {
+            is CommitHash -> metadataRevision.value
+            NewestForVersion -> this.version
+            FromLockfile -> this.getCommitHashFromFileSystem()
+        }
+    val list = listOf(actionYmlUrl(gitRef), actionYamlUrl(gitRef))
     val metadataYaml =
         list.firstNotNullOfOrNull { url ->
             try {

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/MetadataRevision.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/MetadataRevision.kt
@@ -1,0 +1,9 @@
+package io.github.typesafegithub.workflows.actionbindinggenerator
+
+public sealed interface MetadataRevision
+
+public data object NewestForVersion : MetadataRevision
+
+public data object FromLockfile : MetadataRevision
+
+public data class CommitHash(val value: String) : MetadataRevision

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GenerationTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GenerationTest.kt
@@ -39,7 +39,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "simple-action-with-required-string-inputs", "v3")
 
         // when
-        val binding = coords.generateBinding(metadata = actionManifest)
+        val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
 
         // then
         binding.shouldMatchFile("SimpleActionWithRequiredStringInputsV3.kt")
@@ -84,7 +84,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "action-with-some-optional-inputs", "v3")
 
         // when
-        val binding = coords.generateBinding(metadata = actionManifest)
+        val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
 
         // then
         binding.shouldMatchFile("ActionWithSomeOptionalInputsV3.kt")
@@ -159,6 +159,7 @@ class GenerationTest : FunSpec({
         // when
         val binding =
             coords.generateBinding(
+                metadataRevision = FromLockfile,
                 metadata = actionManifest,
                 inputTypings =
                     mapOf(
@@ -201,7 +202,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "action-with-outputs", "v3")
 
         // when
-        val binding = coords.generateBinding(metadata = actionManifest)
+        val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
 
         // then
         binding.shouldMatchFile("ActionWithOutputsV3.kt")
@@ -230,7 +231,11 @@ class GenerationTest : FunSpec({
 
         shouldThrowAny {
             // when
-            coords.generateBinding(metadata = actionManifest, inputTypings = inputTypings)
+            coords.generateBinding(
+                metadataRevision = FromLockfile,
+                metadata = actionManifest,
+                inputTypings = inputTypings,
+            )
         }.shouldHaveMessage(
             // then
             """
@@ -254,7 +259,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "action-with-no-inputs", "v3")
 
         // when
-        val binding = coords.generateBinding(metadata = actionManifest)
+        val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
 
         // then
         binding.shouldMatchFile("ActionWithNoInputsV3.kt")
@@ -273,7 +278,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "deprecated-action", "v2", deprecatedByVersion = "v3")
 
         // when
-        val binding = coords.generateBinding(metadata = actionManifest)
+        val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
 
         // then
         binding.shouldMatchFile("DeprecatedActionV2.kt")
@@ -306,7 +311,7 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "action-with-deprecated-input-and-name-clash", "v2")
 
         // when
-        val binding = coords.generateBinding(metadata = actionManifest)
+        val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
 
         // then
         binding.shouldMatchFile("ActionWithDeprecatedInputAndNameClashV2.kt")
@@ -344,7 +349,12 @@ class GenerationTest : FunSpec({
         val coords = ActionCoords("john-smith", "simple-action-with-lists", "v3")
 
         // when
-        val binding = coords.generateBinding(metadata = actionManifest, inputTypings = inputTypings)
+        val binding =
+            coords.generateBinding(
+                metadataRevision = FromLockfile,
+                metadata = actionManifest,
+                inputTypings = inputTypings,
+            )
 
         // then
         binding.shouldMatchFile("SimpleActionWithListsV3.kt")
@@ -380,6 +390,7 @@ class GenerationTest : FunSpec({
         // when
         val binding =
             coords.generateBinding(
+                metadataRevision = FromLockfile,
                 metadata = actionManifest,
                 inputTypings =
                     mapOf(

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProvidingTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProvidingTest.kt
@@ -44,7 +44,7 @@ class TypesProvidingTest : FunSpec({
         val actionCoord = ActionCoords("some-owner", "some-name", "v1")
 
         // When
-        val types = actionCoord.provideTypes({ actionTypesYml }, { "some-hash" })
+        val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash")) { actionTypesYml }
 
         // Then
         types shouldBe

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/GenerationEntryPoint.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/GenerationEntryPoint.kt
@@ -2,6 +2,7 @@ package io.github.typesafegithub.workflows.codegenerator
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionBinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.FromLockfile
 import io.github.typesafegithub.workflows.actionbindinggenerator.deleteActionTypesYamlCacheIfObsolete
 import io.github.typesafegithub.workflows.actionbindinggenerator.deleteActionYamlCacheIfObsolete
 import io.github.typesafegithub.workflows.actionbindinggenerator.generateBinding
@@ -35,7 +36,7 @@ private fun generateBindings(): List<Pair<ActionBindingRequest, ActionBinding>> 
     val requestsAndBindings =
         bindingsToGenerate.map { actionBindingRequest ->
             println("Generating ${actionBindingRequest.actionCoords.prettyPrint}")
-            val binding = actionBindingRequest.actionCoords.generateBinding()
+            val binding = actionBindingRequest.actionCoords.generateBinding(metadataRevision = FromLockfile)
             Pair(actionBindingRequest, binding)
         }
     requestsAndBindings.forEach { (_, binding) ->

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/updating/CreateActionUpdatePRs.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/updating/CreateActionUpdatePRs.kt
@@ -2,6 +2,7 @@ package io.github.typesafegithub.workflows.codegenerator.updating
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionBinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.CommitHash
 import io.github.typesafegithub.workflows.actionbindinggenerator.generateBinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.isTopLevel
 import io.github.typesafegithub.workflows.actionbindinggenerator.prettyPrint
@@ -79,7 +80,7 @@ private suspend fun createPullRequest(
 
 private fun ActionBindingRequest.generateBindingForCommit(commitHash: String): ActionBinding =
     actionCoords.generateBinding(
-        commitHash = commitHash,
+        metadataRevision = CommitHash(commitHash),
         useCache = false,
     )
 


### PR DESCRIPTION
Before this change, the generator's API wasn't so explicit regarding which revision of the metadata will be fetched. Thanks to the new sealed hierarchy, it's now clear how the generator will behave.