### PR TITLE
[#941] feat(abg): fetch typings maintained with library

### DIFF
--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
@@ -70,16 +70,15 @@ private fun ActionCoords.fetchTypingMetadata(
     return myYaml.decodeFromStringOrDefaultIfEmpty(typesMetadataYaml, ActionTypes())
 }
 
-private fun ActionCoords.fetchFromTypingsMaintainedWithLibrary(
-    fetchUri: (URI) -> String = ::fetchUri,
-): ActionTypes? {
+private fun ActionCoords.fetchFromTypingsMaintainedWithLibrary(fetchUri: (URI) -> String = ::fetchUri): ActionTypes? {
     val url = actionTypesMaintainedWithLibraryUrl()
-    val typesMetadataYml = try {
-        println("  ... types from $url")
-        fetchUri(URI(url))
-    } catch (e: IOException) {
-        null
-    } ?: return null
+    val typesMetadataYml =
+        try {
+            println("  ... types from $url")
+            fetchUri(URI(url))
+        } catch (e: IOException) {
+            null
+        } ?: return null
     return myYaml.decodeFromStringOrDefaultIfEmpty(typesMetadataYml, ActionTypes())
 }
 

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
@@ -14,6 +14,7 @@ internal fun ActionCoords.provideTypes(
 ): Map<String, Typing> =
     getLocalTypings(this)?.let { myYaml.decodeFromString<ActionTypes>(it).toTypesMap() }
         ?: this.fetchTypingMetadata(metadataRevision, fetchUri)?.toTypesMap()
+        ?: this.fetchFromTypingsMaintainedWithLibrary(fetchUri)?.toTypesMap()
         ?: emptyMap()
 
 private val actionTypesYamlDir: File = File("build/action-types-yaml")
@@ -31,6 +32,9 @@ public fun deleteActionTypesYamlCacheIfObsolete() {
 }
 
 private fun ActionCoords.actionTypesYmlUrl(gitRef: String) = "https://raw.githubusercontent.com/$owner/$name/$gitRef/action-types.yml"
+
+private fun ActionCoords.actionTypesMaintainedWithLibraryUrl() =
+    "https://raw.githubusercontent.com/typesafegithub/github-workflows-kt/main/actions/$owner/$name/$version/action-types.yml"
 
 private fun ActionCoords.actionTypesYamlUrl(gitRef: String) = "https://raw.githubusercontent.com/$owner/$name/$gitRef/action-types.yaml"
 
@@ -64,6 +68,19 @@ private fun ActionCoords.fetchTypingMetadata(
     cacheFile.parentFile.mkdirs()
     cacheFile.writeText(typesMetadataYaml)
     return myYaml.decodeFromStringOrDefaultIfEmpty(typesMetadataYaml, ActionTypes())
+}
+
+private fun ActionCoords.fetchFromTypingsMaintainedWithLibrary(
+    fetchUri: (URI) -> String = ::fetchUri,
+): ActionTypes? {
+    val url = actionTypesMaintainedWithLibraryUrl()
+    val typesMetadataYml = try {
+        println("  ... types from $url")
+        fetchUri(URI(url))
+    } catch (e: IOException) {
+        null
+    } ?: return null
+    return myYaml.decodeFromStringOrDefaultIfEmpty(typesMetadataYml, ActionTypes())
 }
 
 internal fun getCommitHash(actionCoords: ActionCoords): String? =


### PR DESCRIPTION
It corresponds to reading locally available typings during bindings generation on the library side. Thanks to this, the client-side generation can benefit form them as well.

Ultimately the typings store (`actions/` directory) from github-workflows-kt will be probably moved to a separate repo.