### PR TITLE
[#941] fix(abg): adjust generated binding for script

### DIFF
--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
@@ -104,26 +104,18 @@ private fun generateActionBindingSourceCode(
             if (generateForScript) "" else "io.github.typesafegithub.workflows.actions.${coords.owner.toKotlinPackageName()}",
             className,
         )
-            .apply {
-                if (!generateForScript) {
-                    addFileComment(
-                        """
-                        This file was generated using action-binding-generator. Don't change it by hand, otherwise your
-                        changes will be overwritten with the next binding code regeneration.
-                        See https://github.com/typesafegithub/github-workflows-kt for more info.
-                        """.trimIndent(),
-                    )
-                }
-            }
+            .addFileComment(
+                """
+                This file was generated using action-binding-generator. Don't change it by hand, otherwise your
+                changes will be overwritten with the next binding code regeneration.
+                See https://github.com/typesafegithub/github-workflows-kt for more info.
+                """.trimIndent(),
+            )
             .addType(generateActionClass(metadata, coords, inputTypings, className, generateForScript = generateForScript))
             .addSuppressAnnotation(metadata, coords)
             .indent("    ")
             .build()
     return buildString {
-        if (generateForScript) {
-            appendLine("#!/usr/bin/env kotlin")
-            appendLine("@file:DependsOn(\"io.github.typesafegithub:github-workflows-kt:$LIBRARY_VERSION\")")
-        }
         fileSpec.writeTo(this)
     }
 }

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GenerationTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GenerationTest.kt
@@ -450,8 +450,9 @@ class GenerationTest : FunSpec({
         //language=kotlin
         binding.kotlinCode shouldBe
             """
-            #!/usr/bin/env kotlin
-            @file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.3.2-SNAPSHOT")
+            // This file was generated using action-binding-generator. Don't change it by hand, otherwise your
+            // changes will be overwritten with the next binding code regeneration.
+            // See https://github.com/typesafegithub/github-workflows-kt for more info.
             @file:Suppress(
                 "DataClassPrivateConstructor",
                 "UNUSED_PARAMETER",


### PR DESCRIPTION
It turned out that it's not necessary to add the dependency on the library or the shebang since the file isn't executed on its own, it's included by other scripts instead.