### PR TITLE
[#941] feat(abg): add util for generating bindings from workflow

### DIFF
--- a/automation/action-binding-generator/api/action-binding-generator.api
+++ b/automation/action-binding-generator/api/action-binding-generator.api
@@ -49,6 +49,10 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/Com
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowKt {
+	public static final fun extractUsedActionsFromWorkflow (Ljava/lang/String;)Ljava/util/List;
+}
+
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/FromLockfile : io/github/typesafegithub/workflows/actionbindinggenerator/MetadataRevision {
 	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/FromLockfile;
 	public fun equals (Ljava/lang/Object;)Z

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflow.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflow.kt
@@ -1,0 +1,46 @@
+package io.github.typesafegithub.workflows.actionbindinggenerator
+
+import com.charleskorn.kaml.Yaml
+import kotlinx.serialization.decodeFromString
+
+internal fun extractUsedActionsFromWorkflow(manifest: String): List<ActionCoords> {
+//    val settings = LoadSettings.builder().build()
+//    val load = Load(settings)
+//    val loadedYaml: Map<String, Any> = load.loadFromString(manifest) as Map<String, Any>
+//    val jobsMap: Map<String, Any> = loadedYaml["jobs"] as Map<String, Any>
+//    val jobName = jobsMap.keys.first()
+//    val usesStrings: List<String> =
+//        ((jobsMap[jobName] as Map<String, Any>)["steps"] as List<Map<String, Any>>)
+//            .map { it["uses"] as String }
+//    return usesStrings
+//        .map {
+//            val (owner, name, version) = it.split('/', '@')
+//            ActionCoords(
+//                owner = owner,
+//                name = name,
+//                version = version,
+//            )
+//        }
+    val myYaml = Yaml(
+        configuration =
+        Yaml.default.configuration.copy(
+            strictMode = false,
+        ),
+    )
+    val parsedWorkflow = myYaml.decodeFromString<Workflow>(manifest)
+    val usesStrings = parsedWorkflow.jobs.flatMap {
+        it.value.steps.mapNotNull { step ->
+            step.uses
+        }
+    }
+
+    return usesStrings
+        .map {
+            val (owner, name, version) = it.split('/', '@')
+            ActionCoords(
+                owner = owner,
+                name = name,
+                version = version,
+            )
+        }
+}

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflow.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflow.kt
@@ -3,7 +3,9 @@ package io.github.typesafegithub.workflows.actionbindinggenerator
 import com.charleskorn.kaml.Yaml
 import kotlinx.serialization.decodeFromString
 
-internal fun extractUsedActionsFromWorkflow(manifest: String): List<ActionCoords> {
+// TODO: cover edge cases in scope of https://github.com/typesafegithub/github-workflows-kt/issues/941
+//  See TODOs in unit tests.
+public fun extractUsedActionsFromWorkflow(manifest: String): List<ActionCoords> {
     val myYaml =
         Yaml(
             configuration =
@@ -19,13 +21,14 @@ internal fun extractUsedActionsFromWorkflow(manifest: String): List<ActionCoords
             }
         }
 
-    return usesStrings
-        .map {
-            val (owner, name, version) = it.split('/', '@')
-            ActionCoords(
-                owner = owner,
-                name = name,
-                version = version,
-            )
-        }
+    return usesStrings.map { it.toActionCoords() }
+}
+
+private fun String.toActionCoords(): ActionCoords {
+    val (owner, name, version) = this.split('/', '@')
+    return ActionCoords(
+        owner = owner,
+        name = name,
+        version = version,
+    )
 }

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflow.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflow.kt
@@ -4,18 +4,20 @@ import com.charleskorn.kaml.Yaml
 import kotlinx.serialization.decodeFromString
 
 internal fun extractUsedActionsFromWorkflow(manifest: String): List<ActionCoords> {
-    val myYaml = Yaml(
-        configuration =
-        Yaml.default.configuration.copy(
-            strictMode = false,
-        ),
-    )
+    val myYaml =
+        Yaml(
+            configuration =
+                Yaml.default.configuration.copy(
+                    strictMode = false,
+                ),
+        )
     val parsedWorkflow = myYaml.decodeFromString<Workflow>(manifest)
-    val usesStrings = parsedWorkflow.jobs.flatMap {
-        it.value.steps.mapNotNull { step ->
-            step.uses
+    val usesStrings =
+        parsedWorkflow.jobs.flatMap {
+            it.value.steps.mapNotNull { step ->
+                step.uses
+            }
         }
-    }
 
     return usesStrings
         .map {

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflow.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflow.kt
@@ -4,23 +4,6 @@ import com.charleskorn.kaml.Yaml
 import kotlinx.serialization.decodeFromString
 
 internal fun extractUsedActionsFromWorkflow(manifest: String): List<ActionCoords> {
-//    val settings = LoadSettings.builder().build()
-//    val load = Load(settings)
-//    val loadedYaml: Map<String, Any> = load.loadFromString(manifest) as Map<String, Any>
-//    val jobsMap: Map<String, Any> = loadedYaml["jobs"] as Map<String, Any>
-//    val jobName = jobsMap.keys.first()
-//    val usesStrings: List<String> =
-//        ((jobsMap[jobName] as Map<String, Any>)["steps"] as List<Map<String, Any>>)
-//            .map { it["uses"] as String }
-//    return usesStrings
-//        .map {
-//            val (owner, name, version) = it.split('/', '@')
-//            ActionCoords(
-//                owner = owner,
-//                name = name,
-//                version = version,
-//            )
-//        }
     val myYaml = Yaml(
         configuration =
         Yaml.default.configuration.copy(

--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GitHubWorkflowModel.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GitHubWorkflowModel.kt
@@ -1,0 +1,18 @@
+package io.github.typesafegithub.workflows.actionbindinggenerator
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class Workflow(
+    val jobs: Map<String, Job>,
+)
+
+@Serializable
+internal data class Job(
+    val steps: List<Step>,
+)
+
+@Serializable
+internal data class Step(
+    val uses: String?,
+)

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowTest.kt
@@ -32,4 +32,16 @@ class ExtractUsedActionsFromWorkflowTest : FunSpec({
                 ActionCoords(owner = "typesafegithub", name = "github-actions-typing", version = "d34db33f"),
             )
     }
+
+    // TEST: nested actions, i.e. where names have some "/"
+
+    // TEST: steps that don't have "uses"
+
+    // TEST: steps using other kinds of actions, like Docker-based or local ones
+
+    // TEST: malformed YAML
+
+    // TEST: no jobs
+
+    // TEST: multiple versions of the same action
 })

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowTest.kt
@@ -33,15 +33,15 @@ class ExtractUsedActionsFromWorkflowTest : FunSpec({
             )
     }
 
-    // TEST: nested actions, i.e. where names have some "/"
+    // TODO nested actions, i.e. where names have some "/"
 
-    // TEST: steps that don't have "uses"
+    // TODO: steps that don't have "uses"
 
-    // TEST: steps using other kinds of actions, like Docker-based or local ones
+    // TODO: steps using other kinds of actions, like Docker-based or local ones
 
-    // TEST: malformed YAML
+    // TODO: malformed YAML
 
-    // TEST: no jobs
+    // TODO: no jobs
 
-    // TEST: multiple versions of the same action
+    // TODO: multiple versions of the same action
 })

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowTest.kt
@@ -1,0 +1,35 @@
+package io.github.typesafegithub.workflows.actionbindinggenerator
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ExtractUsedActionsFromWorkflowTest : FunSpec({
+    test("parses valid manifest") {
+        // Given
+        val manifest =
+            """
+            on:
+              push:
+                branches: [this-branch-must-never-be-created]
+
+            jobs:
+              some-job:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v3
+                  - uses: actions/setup-java@main
+                  - uses: typesafegithub/github-actions-typing@d34db33f
+            """.trimIndent()
+
+        // When
+        val actionCoords = extractUsedActionsFromWorkflow(manifest)
+
+        // Then
+        actionCoords shouldBe
+            listOf(
+                ActionCoords(owner = "actions", name = "checkout", version = "v3"),
+                ActionCoords(owner = "actions", name = "setup-java", version = "main"),
+                ActionCoords(owner = "typesafegithub", name = "github-actions-typing", version = "d34db33f"),
+            )
+    }
+})


### PR DESCRIPTION
Thanks to this, the users will be able to have a YAML file a dummy workflow listing actions that they use in their Kotlin-based workflows, and then use this util function to generate required bindings.

This is not the final API, rather some part of the future plumbing that I'm exposing for now for experimentation.