### PR TITLE
[#941] ci: deliberately downgrade version of action with generated binding

### DIFF
--- a/.github/workflows/actions-versions.yaml
+++ b/.github/workflows/actions-versions.yaml
@@ -48,7 +48,7 @@ jobs:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
     - id: 'step-3'
       name: 'Create issue'
-      uses: 'peter-evans/create-issue-from-file@v4'
+      uses: 'peter-evans/create-issue-from-file@v3'
       with:
         title: 'New major versions of actions available'
         content-filepath: 'build/suggestVersions.md'

--- a/.github/workflows/used-actions.yaml
+++ b/.github/workflows/used-actions.yaml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # List used actions below, as subsequent "- uses" items:
-      - uses: peter-evans/create-issue-from-file@v4
+      - uses: peter-evans/create-issue-from-file@v3


### PR DESCRIPTION
The goal is to test if Renovate works correctly for client-side binding generation.