### PR TITLE
[#941] feat(lib): add YAML file name as arg to bindings generation script

### DIFF
--- a/library/src/main/kotlin/io/github/typesafegithub/workflows/yaml/ToYaml.kt
+++ b/library/src/main/kotlin/io/github/typesafegithub/workflows/yaml/ToYaml.kt
@@ -141,7 +141,7 @@ private fun Workflow.generateYaml(
                     ) {
                         run(
                             name = "Generate action bindings",
-                            command = ".github/workflows/$GENERATE_ACTION_BINDINGS_SCRIPT_NAME",
+                            command = ".github/workflows/$GENERATE_ACTION_BINDINGS_SCRIPT_NAME \"$targetFileName\"",
                         )
                     }
 


### PR DESCRIPTION
It's helpful to make the script generate bindings needed only by a
given workflow.
