### PR TITLE
[#941] fix(abg): support steps not only with 'uses' fields

### DIFF
--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GitHubWorkflowModel.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GitHubWorkflowModel.kt
@@ -14,5 +14,5 @@ internal data class Job(
 
 @Serializable
 internal data class Step(
-    val uses: String?,
+    val uses: String? = null,
 )

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowTest.kt
@@ -4,7 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class ExtractUsedActionsFromWorkflowTest : FunSpec({
-    test("parses valid manifest") {
+    test("parses valid manifest just with 'uses' steps") {
         // Given
         val manifest =
             """
@@ -33,9 +33,34 @@ class ExtractUsedActionsFromWorkflowTest : FunSpec({
             )
     }
 
-    // TODO nested actions, i.e. where names have some "/"
+    test("workflow with not only with 'uses' steps") {
+        // Given
+        val manifest =
+            """
+            on:
+              push:
 
-    // TODO: steps that don't have "uses"
+            jobs:
+              some-job:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v3
+                  - run: echo "Hello world!"
+                  - uses: actions/setup-java@main
+            """.trimIndent()
+
+        // When
+        val actionCoords = extractUsedActionsFromWorkflow(manifest)
+
+        // Then
+        actionCoords shouldBe
+            listOf(
+                ActionCoords(owner = "actions", name = "checkout", version = "v3"),
+                ActionCoords(owner = "actions", name = "setup-java", version = "main"),
+            )
+    }
+
+    // TODO nested actions, i.e. where names have some "/"
 
     // TODO: steps using other kinds of actions, like Docker-based or local ones
 


### PR DESCRIPTION
Other kinds of steps, e.g. with `run`, have to be parseable as well.
