### PR TITLE
chore(lib): switch from com.github.tschuchortdev:kotlin-compile-testing to dev.zacsweers.kctfork

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -23,8 +23,10 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.0")
 
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
-    testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.5.0")
+    testImplementation("dev.zacsweers.kctfork:core:0.4.0")
     testImplementation("com.lemonappdev:konsist:0.13.0")
+    // Needed to use the right version of the compiler for the libraries that depend on it.
+    testImplementation(kotlin("compiler"))
     testImplementation(kotlin("reflect"))
 }
 

--- a/library/src/test/kotlin/io/github/typesafegithub/workflows/NonCompilableTest.kt
+++ b/library/src/test/kotlin/io/github/typesafegithub/workflows/NonCompilableTest.kt
@@ -1,5 +1,6 @@
 package io.github.typesafegithub.workflows
 
+import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import com.tschuchort.compiletesting.SourceFile
@@ -7,7 +8,9 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
+@OptIn(ExperimentalCompilerApi::class)
 class NonCompilableTest : FunSpec({
     test("job nested inside a job") {
         val compilationResult =
@@ -83,9 +86,10 @@ class NonCompilableTest : FunSpec({
     }
 })
 
+@OptIn(ExperimentalCompilerApi::class)
 private fun compile(
     @Language("kotlin") code: String,
-): KotlinCompilation.Result =
+): JvmCompilationResult =
     KotlinCompilation().apply {
         sources =
             listOf(

--- a/library/src/test/kotlin/io/github/typesafegithub/workflows/NonCompilableTest.kt
+++ b/library/src/test/kotlin/io/github/typesafegithub/workflows/NonCompilableTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
 package io.github.typesafegithub.workflows
 
 import com.tschuchort.compiletesting.JvmCompilationResult
@@ -10,7 +12,6 @@ import io.kotest.matchers.string.shouldContain
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
-@OptIn(ExperimentalCompilerApi::class)
 class NonCompilableTest : FunSpec({
     test("job nested inside a job") {
         val compilationResult =
@@ -86,7 +87,6 @@ class NonCompilableTest : FunSpec({
     }
 })
 
-@OptIn(ExperimentalCompilerApi::class)
 private fun compile(
     @Language("kotlin") code: String,
 ): JvmCompilationResult =


### PR DESCRIPTION
It's an updated fork of com.github.tschuchortdev:kotlin-compile-testing. Most importantly, it supports newer versions of Kotlin.

Needed as a prerequisite for #1066.