### PR TITLE
[#1071] ci: use generateActionBindings helper

### DIFF
--- a/.github/workflows/generate-action-bindings.main.kts
+++ b/.github/workflows/generate-action-bindings.main.kts
@@ -1,6 +1,6 @@
 #!/usr/bin/env kotlin
 @file:Repository("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-@file:DependsOn("io.github.typesafegithub:action-binding-generator:1.4.1-20231109.091111-23")
+@file:DependsOn("io.github.typesafegithub:action-binding-generator:1.4.1-20231109.093107-24")
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.generateActionBindings
 

--- a/.github/workflows/generate-action-bindings.main.kts
+++ b/.github/workflows/generate-action-bindings.main.kts
@@ -1,37 +1,7 @@
 #!/usr/bin/env kotlin
 @file:Repository("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-@file:DependsOn("io.github.typesafegithub:action-binding-generator:1.4.1-20231029.205542-12")
+@file:DependsOn("io.github.typesafegithub:action-binding-generator:1.4.1-20231109.091111-23")
 
-import io.github.typesafegithub.workflows.actionbindinggenerator.NewestForVersion
-import io.github.typesafegithub.workflows.actionbindinggenerator.extractUsedActionsFromWorkflow
-import io.github.typesafegithub.workflows.actionbindinggenerator.generateBinding
-import java.io.File
-import kotlin.io.path.Path
+import io.github.typesafegithub.workflows.actionbindinggenerator.generateActionBindings
 
-val workflowYamlFileName: String? = when {
-    args.isEmpty() -> null
-    args.size == 1 -> args[0]
-    else -> error("At most one argument is supported!")
-}
-
-val allUsedActions = extractUsedActionsFromWorkflow(
-    manifest = File(".github/workflows/_used-actions.yaml").readText(),
-)
-
-val actionsToGenerateBindingsFor = workflowYamlFileName?.let {
-    val actionsUsedInRequestedWorkflow = extractUsedActionsFromWorkflow(
-        manifest = File(".github/workflows/$workflowYamlFileName").readText(),
-    )
-    allUsedActions.intersect(actionsUsedInRequestedWorkflow.toSet())
-} ?: allUsedActions
-
-actionsToGenerateBindingsFor.forEach { action ->
-    Path(".github").resolve("workflows").resolve("generated").resolve(action.owner).resolve("${action.name}.kt").let {
-        it.parent.toFile().mkdirs()
-        val binding = action.generateBinding(
-            metadataRevision = NewestForVersion,
-            generateForScript = true,
-        )
-        it.toFile().writeText(binding.kotlinCode)
-    }
-}
+generateActionBindings(args)


### PR DESCRIPTION
The library now provides a helper function for implementing the logic required for bindings generation.