### PR TITLE
[#1071] fix(abg): fix false error in extracting used actions

### DIFF
--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflow.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflow.kt
@@ -27,8 +27,8 @@ private fun parseWorkflow(manifest: String) =
 private fun assertSingleVersionForEachAction(actionCoords: List<ActionCoords>) {
     val actionsWithMultipleVersions =
         actionCoords
-            .groupingBy { "${it.owner}/${it.name}" }
-            .eachCount()
+            .groupBy { "${it.owner}/${it.name}" }
+            .mapValues { it.value.toSet().size }
             .filterValues { it > 1 }
             .keys
     if (actionsWithMultipleVersions.isNotEmpty()) {

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/ExtractUsedActionsFromWorkflowTest.kt
@@ -104,6 +104,10 @@ class ExtractUsedActionsFromWorkflowTest : FunSpec({
                   - uses: actions/checkout@v3
                   - uses: actions/setup-java@v4
                   - uses: actions/checkout@v5
+              another-job:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/setup-java@v4
             """.trimIndent()
 
         // Then


### PR DESCRIPTION
Multiple usages of the same action in the same version were mistakenly
interpreted as more than one version used.