### PR TITLE
Replace $dollar with \$ in ordinary string literals

### DIFF
--- a/library/src/test/kotlin/io/github/typesafegithub/workflows/dsl/expressions/ContextsTest.kt
+++ b/library/src/test/kotlin/io/github/typesafegithub/workflows/dsl/expressions/ContextsTest.kt
@@ -7,22 +7,20 @@ import io.kotest.matchers.shouldBe
 @Suppress("VariableNaming", "ktlint:standard:property-naming")
 class ContextsTest : FunSpec({
 
-    val dollar = '$'.toString()
-
     test("Environment variables") {
         assertSoftly {
             val DAY_OF_WEEK by Contexts.env
-            "$DAY_OF_WEEK == 'Monday'" shouldBe "${dollar}DAY_OF_WEEK == 'Monday'"
+            "$DAY_OF_WEEK == 'Monday'" shouldBe "\$DAY_OF_WEEK == 'Monday'"
 
             "${Contexts.env.CI} == true && ${Contexts.env.GITHUB_ACTIONS} == true" shouldBe
-                "${dollar}CI == true && ${dollar}GITHUB_ACTIONS == true"
+                "\$CI == true && \$GITHUB_ACTIONS == true"
         }
     }
 
     test("Environment variables from expressions") {
         val GREETING by Contexts.env
-        expr { GREETING } shouldBe "$dollar{{ GREETING }}"
-        expr { env.GITHUB_ACTIONS } shouldBe "$dollar{{ GITHUB_ACTIONS }}"
+        expr { GREETING } shouldBe "\${{ GREETING }}"
+        expr { env.GITHUB_ACTIONS } shouldBe "\${{ GITHUB_ACTIONS }}"
     }
 
     test("Secrets") {


### PR DESCRIPTION
It unfortunately doesn't work in multiline strings, that's why I didn't change anything in `IntegrationTest`.

In ordinary string literals though, it does, and I believe it's a bit cleaner.