### PR TITLE
refactor(automation): stop reading local action typings

### DIFF
--- a/automation/typings/src/main/kotlin/io/github/typesafegithub/workflows/actionsmetadata/model/ActionBindingRequest.kt
+++ b/automation/typings/src/main/kotlin/io/github/typesafegithub/workflows/actionsmetadata/model/ActionBindingRequest.kt
@@ -11,5 +11,4 @@ sealed interface TypingsSource {
 
 data class ActionBindingRequest(
     val actionCoords: ActionCoords,
-    val typingsSource: TypingsSource = TypingsSource.CodeGenerator(),
 )


### PR DESCRIPTION
Part of #1072.

They are not needed anymore - the action bindings generator can already fetch them
either from the action itself, or from the typings catalog.