### PR TITLE
ci: disable Gradle configuration cache for releasing tasks

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -65,7 +65,7 @@ workflow(
                 name = "Publish '$library' to Sonatype",
                 condition = expr("steps.${setIsSnapshotVersionFlag.id}.outputs.is-snapshot == 'true'"),
                 action = GradleBuildAction(
-                    arguments = "$library:publishToSonatype closeAndReleaseSonatypeStagingRepository",
+                    arguments = "$library:publishToSonatype closeAndReleaseSonatypeStagingRepository --no-configuration-cache",
                 ),
             )
         }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,13 +90,13 @@ jobs:
       name: 'Publish '':library'' to Sonatype'
       uses: 'gradle/gradle-build-action@v2'
       with:
-        arguments: ':library:publishToSonatype closeAndReleaseSonatypeStagingRepository'
+        arguments: ':library:publishToSonatype closeAndReleaseSonatypeStagingRepository --no-configuration-cache'
       if: '${{ steps.step-2.outputs.is-snapshot == ''true'' }}'
     - id: 'step-4'
       name: 'Publish '':automation:action-binding-generator'' to Sonatype'
       uses: 'gradle/gradle-build-action@v2'
       with:
-        arguments: ':automation:action-binding-generator:publishToSonatype closeAndReleaseSonatypeStagingRepository'
+        arguments: ':automation:action-binding-generator:publishToSonatype closeAndReleaseSonatypeStagingRepository --no-configuration-cache'
       if: '${{ steps.step-2.outputs.is-snapshot == ''true'' }}'
   build_docs:
     name: 'Build docs'

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -45,7 +45,7 @@ workflow(
             uses(
                 name = "Publish '$library' to Sonatype",
                 action = GradleBuildAction(
-                    arguments = "$library:publishToSonatype closeAndReleaseSonatypeStagingRepository",
+                    arguments = "$library:publishToSonatype closeAndReleaseSonatypeStagingRepository --no-configuration-cache",
                 ),
             )
         }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,12 +55,12 @@ jobs:
       name: 'Publish '':library'' to Sonatype'
       uses: 'gradle/gradle-build-action@v2'
       with:
-        arguments: ':library:publishToSonatype closeAndReleaseSonatypeStagingRepository'
+        arguments: ':library:publishToSonatype closeAndReleaseSonatypeStagingRepository --no-configuration-cache'
     - id: 'step-5'
       name: 'Publish '':automation:action-binding-generator'' to Sonatype'
       uses: 'gradle/gradle-build-action@v2'
       with:
-        arguments: ':automation:action-binding-generator:publishToSonatype closeAndReleaseSonatypeStagingRepository'
+        arguments: ':automation:action-binding-generator:publishToSonatype closeAndReleaseSonatypeStagingRepository --no-configuration-cache'
     - id: 'step-6'
       name: 'Wait until '':library'' present in Maven Central'
       uses: 'gradle/gradle-build-action@v2'


### PR DESCRIPTION
Part of #890.

These tasks contain elements that make them not compatible with configuration caching. It will likely be fixed in the future.