### PR TITLE
fix(automation): allow having non-existent fields in typings

### DIFF
--- a/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
+++ b/automation/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Generation.kt
@@ -50,7 +50,6 @@ public fun ActionCoords.generateBinding(
     }
 
     val metadataProcessed = metadata.removeDeprecatedInputsIfNameClash()
-    checkPropertiesAreValid(metadataProcessed, inputTypings.first)
     metadataProcessed.suggestAdditionalTypings(inputTypings.first.keys)?.let { formatSuggestions ->
         println("$prettyPrint I suggest the following typings:\n$formatSuggestions")
     }
@@ -78,20 +77,6 @@ private fun Metadata.removeDeprecatedInputsIfNameClash(): Metadata {
                     ?: clashingInputs.first()
             }.values.associateBy({ it.key }, { it.value })
     return this.copy(inputs = newInputs)
-}
-
-private fun checkPropertiesAreValid(
-    metadata: Metadata,
-    inputTypings: Map<String, Typing>,
-) {
-    val invalidProperties = inputTypings.keys - metadata.inputs.keys
-    require(invalidProperties.isEmpty()) {
-        """
-        Request contains invalid properties:
-        Available: ${metadata.inputs.keys}
-        Invalid:   $invalidProperties
-        """.trimIndent()
-    }
 }
 
 private fun generateActionBindingSourceCode(

--- a/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GenerationTest.kt
+++ b/automation/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/GenerationTest.kt
@@ -1,10 +1,8 @@
 package io.github.typesafegithub.workflows.actionbindinggenerator
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.TypingActualSource.ACTION
-import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.throwable.shouldHaveMessage
 
 class GenerationTest : FunSpec({
     test("action with required inputs as strings, no outputs") {
@@ -211,47 +209,6 @@ class GenerationTest : FunSpec({
 
         // then
         binding.shouldMatchFile("ActionWithOutputsV3.kt")
-    }
-
-    test("Detect binding request with invalid properties") {
-        // given
-        val input = Input("input", "default", required = true)
-        val actionManifest =
-            Metadata(
-                name = "Do something cool",
-                description = "This is a test description that should be put in the KDoc comment for a class",
-                inputs =
-                    mapOf(
-                        "foo-bar" to input,
-                        "baz-goo" to input,
-                    ),
-            )
-        val inputTypings =
-            Pair(
-                mapOf(
-                    "check-latest" to BooleanTyping,
-                    "foo-bar" to BooleanTyping,
-                    "bazGoo" to BooleanTyping,
-                ),
-                ACTION,
-            )
-        val coords = ActionCoords("actions", "setup-node", "v2")
-
-        shouldThrowAny {
-            // when
-            coords.generateBinding(
-                metadataRevision = FromLockfile,
-                metadata = actionManifest,
-                inputTypings = inputTypings,
-            )
-        }.shouldHaveMessage(
-            // then
-            """
-            Request contains invalid properties:
-            Available: [foo-bar, baz-goo]
-            Invalid:   [check-latest, bazGoo]
-            """.trimIndent(),
-        )
     }
 
     test("action with no inputs") {


### PR DESCRIPTION
Part of #1151.

It's needed to have forward compatibility, i.e. to let the typings reflect some newer version of the action, and still using a bit older action manifest (action.yml).

# Testing

https://github.com/typesafegithub/github-workflows-kt/actions/runs/7044641012