### PR TITLE
fix(ci): do not use Gradle config cache with Dokka

### DIFF
--- a/.github/workflows/release-common.main.kts
+++ b/.github/workflows/release-common.main.kts
@@ -16,7 +16,7 @@ fun JobBuilder<*>.deployDocs() {
     uses(
         name = "Generate API docs",
         action = GradleBuildAction(
-            arguments = ":library:dokkaHtml",
+            arguments = ":library:dokkaHtml --no-configuration-cache",
         ),
     )
     run(

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -48,7 +48,7 @@ jobs:
       name: 'Generate API docs'
       uses: 'gradle/gradle-build-action@v2'
       with:
-        arguments: ':library:dokkaHtml'
+        arguments: ':library:dokkaHtml --no-configuration-cache'
     - id: 'step-6'
       name: 'Prepare target directory for API docs'
       run: 'mkdir -p to-gh-pages/api-docs'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       name: 'Generate API docs'
       uses: 'gradle/gradle-build-action@v2'
       with:
-        arguments: ':library:dokkaHtml'
+        arguments: ':library:dokkaHtml --no-configuration-cache'
     - id: 'step-11'
       name: 'Prepare target directory for API docs'
       run: 'mkdir -p to-gh-pages/api-docs'


### PR DESCRIPTION
Part of #1174.

Apparently Dokka doesn't support Gradle configuration cache yet.