### PR TITLE
refactor: extract Path.findGitRoot() to separate module

### DIFF
--- a/github-workflows-kt/build.gradle.kts
+++ b/github-workflows-kt/build.gradle.kts
@@ -21,6 +21,7 @@ version = rootProject.version
 dependencies {
     implementation("org.snakeyaml:snakeyaml-engine:2.7")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.2")
+    implementation(projects.sharedInternal)
 
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     testImplementation("dev.zacsweers.kctfork:core:0.4.0")

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/internal/PathUtils.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/internal/PathUtils.kt
@@ -2,15 +2,6 @@ package io.github.typesafegithub.workflows.internal
 
 import java.nio.file.Path
 import kotlin.io.path.absolute
-import kotlin.io.path.exists
-import kotlin.io.path.isDirectory
 import kotlin.io.path.relativeTo
-
-internal fun Path.findGitRoot(): Path {
-    return generateSequence(absolute()) { it.parent }
-        .firstOrNull {
-            it.resolve(".git")?.let { it.exists() && it.isDirectory() } ?: false
-        } ?: error("could not find a git root from ${this.absolute()}")
-}
 
 internal fun Path.relativeToAbsolute(base: Path): Path = absolute().relativeTo(base.absolute())

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/ToYaml.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/ToYaml.kt
@@ -7,8 +7,8 @@ import io.github.typesafegithub.workflows.domain.Permission
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
 import io.github.typesafegithub.workflows.domain.Workflow
 import io.github.typesafegithub.workflows.dsl.toBuilder
-import io.github.typesafegithub.workflows.internal.findGitRoot
 import io.github.typesafegithub.workflows.internal.relativeToAbsolute
+import io.github.typesafegithub.workflows.shared.internal.findGitRoot
 import io.github.typesafegithub.workflows.yaml.Preamble.Just
 import io.github.typesafegithub.workflows.yaml.Preamble.WithOriginalAfter
 import io.github.typesafegithub.workflows.yaml.Preamble.WithOriginalBefore

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,7 @@ apply(from = "./buildSrc/repositories.settings.gradle.kts")
 include(
     "github-workflows-kt",
     "action-binding-generator",
+    "shared-internal",
     ":automation:typings",
     ":automation:code-generator",
 )

--- a/shared-internal/build.gradle.kts
+++ b/shared-internal/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    buildsrc.convention.`kotlin-jvm`
+    buildsrc.convention.publishing
+}
+
+group = rootProject.group
+version = rootProject.version

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/PathUtils.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/PathUtils.kt
@@ -1,0 +1,13 @@
+package io.github.typesafegithub.workflows.shared.internal
+
+import java.nio.file.Path
+import kotlin.io.path.absolute
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+
+fun Path.findGitRoot(): Path {
+    return generateSequence(this.absolute()) { it.parent }
+        .firstOrNull {
+            it.resolve(".git")?.let { it.exists() && it.isDirectory() } ?: false
+        } ?: error("could not find a git root from ${this.absolute()}")
+}


### PR DESCRIPTION
Part of #1071, to be able to share this function across modules.
