### PR TITLE
chore: rename root project to '...-monorepo'

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "github-workflows-kt-root"
+rootProject.name = "github-workflows-kt-monorepo"
 
 apply(from = "./buildSrc/repositories.settings.gradle.kts")
 


### PR DESCRIPTION
"...-root" looks weird in the project picker view in IntelliJ. Monorepo expresses the intent better.