### PR TITLE
refactor: consolidate 'typings' module into 'code-generator'

### DIFF
--- a/automation/code-generator/build.gradle.kts
+++ b/automation/code-generator/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json")
     implementation("io.arrow-kt:arrow-fx-coroutines:1.2.1")
 
-    implementation(projects.automation.typings)
     implementation(projects.actionBindingGenerator)
 
     testImplementation(projects.githubWorkflowsKt)

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/ActionBindingsToGenerate.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/ActionBindingsToGenerate.kt
@@ -1,0 +1,3 @@
+package io.github.typesafegithub.workflows.codegenerator
+
+val bindingsToGenerate by lazy { readActionsMetadata() }

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/ActionsDocsGeneration.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/ActionsDocsGeneration.kt
@@ -3,8 +3,8 @@ package io.github.typesafegithub.workflows.codegenerator
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionBinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.TypingActualSource
-import io.github.typesafegithub.workflows.actionsmetadata.model.ActionBindingRequest
-import io.github.typesafegithub.workflows.actionsmetadata.model.Version
+import io.github.typesafegithub.workflows.codegenerator.model.ActionBindingRequest
+import io.github.typesafegithub.workflows.codegenerator.model.Version
 import java.nio.file.Paths
 
 internal fun generateListOfBindingsForDocs(requestsAndBindings: List<Pair<ActionBindingRequest, ActionBinding>>) {

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/ActionsMetadataReading.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/ActionsMetadataReading.kt
@@ -1,8 +1,8 @@
-package io.github.typesafegithub.workflows.actionsmetadata
+package io.github.typesafegithub.workflows.codegenerator
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.prettyPrint
-import io.github.typesafegithub.workflows.actionsmetadata.model.ActionBindingRequest
+import io.github.typesafegithub.workflows.codegenerator.model.ActionBindingRequest
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.isRegularFile

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/AddDeprecationInfo.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/AddDeprecationInfo.kt
@@ -1,7 +1,7 @@
-package io.github.typesafegithub.workflows.actionsmetadata
+package io.github.typesafegithub.workflows.codegenerator
 
-import io.github.typesafegithub.workflows.actionsmetadata.model.ActionBindingRequest
-import io.github.typesafegithub.workflows.actionsmetadata.model.Version
+import io.github.typesafegithub.workflows.codegenerator.model.ActionBindingRequest
+import io.github.typesafegithub.workflows.codegenerator.model.Version
 
 fun List<ActionBindingRequest>.addDeprecationInfo(): List<ActionBindingRequest> =
     this.groupBy { "${it.actionCoords.owner}/${it.actionCoords.name}" }

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/GenerationEntryPoint.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/GenerationEntryPoint.kt
@@ -5,8 +5,7 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.ActionBinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.FromLockfile
 import io.github.typesafegithub.workflows.actionbindinggenerator.generateBinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.prettyPrint
-import io.github.typesafegithub.workflows.actionsmetadata.bindingsToGenerate
-import io.github.typesafegithub.workflows.actionsmetadata.model.ActionBindingRequest
+import io.github.typesafegithub.workflows.codegenerator.model.ActionBindingRequest
 import io.github.typesafegithub.workflows.dsl.expressions.generateEventPayloads
 import java.nio.file.Paths
 

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/model/ActionBindingRequest.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/model/ActionBindingRequest.kt
@@ -1,4 +1,4 @@
-package io.github.typesafegithub.workflows.actionsmetadata.model
+package io.github.typesafegithub.workflows.codegenerator.model
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionCoords
 

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/model/Version.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/model/Version.kt
@@ -1,4 +1,4 @@
-package io.github.typesafegithub.workflows.actionsmetadata.model
+package io.github.typesafegithub.workflows.codegenerator.model
 
 data class Version(val version: String) : Comparable<Version> {
     val input: String = version.removePrefix("v").removePrefix("V")

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/updating/CreateActionUpdatePRs.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/updating/CreateActionUpdatePRs.kt
@@ -6,8 +6,8 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.CommitHash
 import io.github.typesafegithub.workflows.actionbindinggenerator.generateBinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.isTopLevel
 import io.github.typesafegithub.workflows.actionbindinggenerator.prettyPrint
-import io.github.typesafegithub.workflows.actionsmetadata.bindingsToGenerate
-import io.github.typesafegithub.workflows.actionsmetadata.model.ActionBindingRequest
+import io.github.typesafegithub.workflows.codegenerator.bindingsToGenerate
+import io.github.typesafegithub.workflows.codegenerator.model.ActionBindingRequest
 import io.github.typesafegithub.workflows.codegenerator.versions.GithubRef
 import io.github.typesafegithub.workflows.codegenerator.versions.GithubTag
 import io.github.typesafegithub.workflows.codegenerator.versions.getGithubToken

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/Http.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/Http.kt
@@ -1,7 +1,7 @@
 package io.github.typesafegithub.workflows.codegenerator.versions
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionCoords
-import io.github.typesafegithub.workflows.actionsmetadata.model.Version
+import io.github.typesafegithub.workflows.codegenerator.model.Version
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/SuggestVersions.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/SuggestVersions.kt
@@ -3,8 +3,8 @@ package io.github.typesafegithub.workflows.codegenerator.versions
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.isTopLevel
 import io.github.typesafegithub.workflows.actionbindinggenerator.prettyPrint
-import io.github.typesafegithub.workflows.actionsmetadata.bindingsToGenerate
-import io.github.typesafegithub.workflows.actionsmetadata.model.Version
+import io.github.typesafegithub.workflows.codegenerator.bindingsToGenerate
+import io.github.typesafegithub.workflows.codegenerator.model.Version
 import java.io.File
 
 /**

--- a/automation/code-generator/src/test/kotlin/io/github/typesafegithub/workflows/codegenerator/AddDeprecationInfoTest.kt
+++ b/automation/code-generator/src/test/kotlin/io/github/typesafegithub/workflows/codegenerator/AddDeprecationInfoTest.kt
@@ -1,7 +1,7 @@
-package io.github.typesafegithub.workflows.actionsmetadata
+package io.github.typesafegithub.workflows.codegenerator
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.ActionCoords
-import io.github.typesafegithub.workflows.actionsmetadata.model.ActionBindingRequest
+import io.github.typesafegithub.workflows.codegenerator.model.ActionBindingRequest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 

--- a/automation/code-generator/src/test/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/SuggestVersionsTest.kt
+++ b/automation/code-generator/src/test/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/SuggestVersionsTest.kt
@@ -1,6 +1,6 @@
 package io.github.typesafegithub.workflows.codegenerator.versions
 
-import io.github.typesafegithub.workflows.actionsmetadata.model.Version
+import io.github.typesafegithub.workflows.codegenerator.model.Version
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.Table2

--- a/automation/typings/README.md
+++ b/automation/typings/README.md
@@ -1,7 +1,0 @@
-# Module's purpose
-
-This module is responsible for reading metadata about actions for which Kotlin bindings should be generated.
-
-It uses data stored in `actions` root directory and produces a collection of Kotlin objects expressing actions supported
-by the library. This collection is available as a `bindingsToGenerate` list in
-[BindingsToGenerate.kt](src/main/kotlin/io/github/typesafegithub/workflows/actionsmetadata/BindingsToGenerate.kt).

--- a/automation/typings/build.gradle.kts
+++ b/automation/typings/build.gradle.kts
@@ -1,7 +1,0 @@
-plugins {
-    buildsrc.convention.`kotlin-jvm`
-}
-
-dependencies {
-    implementation(projects.actionBindingGenerator)
-}

--- a/automation/typings/src/main/kotlin/io/github/typesafegithub/workflows/actionsmetadata/ActionBindingsToGenerate.kt
+++ b/automation/typings/src/main/kotlin/io/github/typesafegithub/workflows/actionsmetadata/ActionBindingsToGenerate.kt
@@ -1,3 +1,0 @@
-package io.github.typesafegithub.workflows.actionsmetadata
-
-val bindingsToGenerate by lazy { readActionsMetadata() }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,6 @@ include(
     "github-workflows-kt",
     "action-binding-generator",
     "shared-internal",
-    ":automation:typings",
     ":automation:code-generator",
 )
 


### PR DESCRIPTION
There's no point in keeping this module separate, now that we moved the typings to github-actions-typing-catalog.