### PR TITLE
feat(abg): use typings for older version if available

### DIFF
--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/TypesProviding.kt
@@ -3,6 +3,7 @@ package io.github.typesafegithub.workflows.actionbindinggenerator
 import com.charleskorn.kaml.Yaml
 import io.github.typesafegithub.workflows.actionbindinggenerator.TypingActualSource.ACTION
 import io.github.typesafegithub.workflows.actionbindinggenerator.TypingActualSource.TYPING_CATALOG
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import java.io.IOException
 import java.net.URI
@@ -25,6 +26,10 @@ private fun ActionCoords.actionTypesYmlUrl(gitRef: String) =
 private fun ActionCoords.actionTypesFromCatalog() =
     "https://raw.githubusercontent.com/typesafegithub/github-actions-typing-catalog/" +
         "main/typings/$owner/$repoName/$version/$subName/action-types.yml"
+
+private fun ActionCoords.catalogMetadata() =
+    "https://raw.githubusercontent.com/typesafegithub/github-actions-typing-catalog/" +
+        "main/typings/$owner/$repoName/metadata.yml"
 
 private fun ActionCoords.actionTypesYamlUrl(gitRef: String) =
     "https://raw.githubusercontent.com/$owner/$repoName/$gitRef/$subName/action-types.yaml"
@@ -54,7 +59,34 @@ private fun ActionCoords.fetchTypingMetadata(
 }
 
 private fun ActionCoords.fetchFromTypingsFromCatalog(fetchUri: (URI) -> String = ::fetchUri): Pair<ActionTypes, TypingActualSource>? =
-    fetchTypingsFromUrl(url = actionTypesFromCatalog(), fetchUri = fetchUri)?.let { Pair(it, TYPING_CATALOG) }
+    (
+        fetchTypingsFromUrl(url = actionTypesFromCatalog(), fetchUri = fetchUri)
+            ?: fetchTypingsForOlderVersionFromCatalog(fetchUri = fetchUri)
+    )
+        ?.let { Pair(it, TYPING_CATALOG) }
+
+private fun ActionCoords.fetchTypingsForOlderVersionFromCatalog(fetchUri: (URI) -> String): ActionTypes? {
+    val metadataUrl = this.catalogMetadata()
+    val metadataYml =
+        try {
+            println("  ... metadata from $metadataUrl")
+            fetchUri(URI(metadataUrl))
+        } catch (e: IOException) {
+            return null
+        }
+    val metadata = myYaml.decodeFromString<CatalogMetadata>(metadataYml)
+    val fallbackVersion =
+        metadata.versionsWithTypings
+            .filter { it.versionToInt() < this.version.versionToInt() }
+            .maxByOrNull { it.versionToInt() }
+            ?: run {
+                println("  ... no fallback version found!")
+                return null
+            }
+    println("  ... using fallback version: $fallbackVersion")
+    val adjustedCoords = this.copy(version = fallbackVersion)
+    return fetchTypingsFromUrl(url = adjustedCoords.actionTypesFromCatalog(), fetchUri = fetchUri)
+}
 
 private fun fetchTypingsFromUrl(
     url: String,
@@ -118,3 +150,10 @@ private inline fun <reified T> Yaml.decodeFromStringOrDefaultIfEmpty(
     } else {
         default
     }
+
+private fun String.versionToInt() = lowercase().removePrefix("v").toInt()
+
+@Serializable
+private data class CatalogMetadata(
+    val versionsWithTypings: List<String>,
+)


### PR DESCRIPTION
Fixes #1073.

If there's no typings for a given version in the catalog, typings for an older version is tried to be fetched. Thanks to this, we cover a scenario where usually the next version of some action doesn't need to have typings defined immediately because the older version is fine. It doesn't account for breaking changes where this approach will produce an incorrect binding, however in practice it should be better than what we have now.

It doesn't hold for action-hosted typings.