### PR TITLE
fix(gwkt): allow script names with spaces for Kotlin-based steps

### DIFF
--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/dsl/JobBuilder.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/dsl/JobBuilder.kt
@@ -126,7 +126,7 @@ public class JobBuilder<OUTPUT : JobOutputs>(
                 // Because of the current architecture, it's hard to make this command work properly if the sourceFile
                 // isn't in .github/workflows directory. It's the most common use case, though, so for now this
                 // simplified implementation is used.
-                command = "GHWKT_RUN_STEP='${this.id}:$id' .github/workflows/${sourceFile.name}",
+                command = "GHWKT_RUN_STEP='${this.id}:$id' '.github/workflows/${sourceFile.name}'",
                 logic = logic,
                 env = env,
                 condition = `if` ?: condition,

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/IntegrationTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/IntegrationTest.kt
@@ -930,7 +930,7 @@ class IntegrationTest : FunSpec({
                   uses: 'actions/checkout@v4'
                 - id: 'step-1'
                   name: 'Step with Kotlin code in lambda'
-                  run: 'GHWKT_RUN_STEP=''test:step-1'' .github/workflows/some_workflow.main.kts'
+                  run: 'GHWKT_RUN_STEP=''test:step-1'' ''.github/workflows/some_workflow.main.kts'''
 
             """.trimIndent()
         callCount shouldBe 1


### PR DESCRIPTION
Part of #1295.