### PR TITLE
feat(abg): create enum for binding generation modes

### DIFF
--- a/action-binding-generator/api/action-binding-generator.api
+++ b/action-binding-generator/api/action-binding-generator.api
@@ -81,6 +81,14 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/gen
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/generation/ClientType : java/lang/Enum {
+	public static final field BUNDLED_WITH_LIB Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ClientType;
+	public static final field CLIENT_SIDE_GENERATION Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ClientType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ClientType;
+	public static fun values ()[Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ClientType;
+}
+
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/generation/ExtractUsedActionsFromWorkflowKt {
 	public static final fun extractUsedActionsFromWorkflow (Ljava/lang/String;)Ljava/util/List;
 }
@@ -90,8 +98,8 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/gen
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationKt {
-	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;Z)Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ActionBinding;
-	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;ZILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ActionBinding;
+	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ClientType;)Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ActionBinding;
+	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ClientType;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ActionBinding;
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/metadata/Input {

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerateActionBindingsCliHelper.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerateActionBindingsCliHelper.kt
@@ -49,7 +49,7 @@ public fun generateActionBindings(
             val binding =
                 action.generateBinding(
                     metadataRevision = NewestForVersion,
-                    generateForScript = true,
+                    clientType = ClientType.CLIENT_SIDE_GENERATION,
                 )
             it.toFile().writeText(binding.kotlinCode)
         }

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -388,7 +388,7 @@ class GenerationTest : FunSpec({
         binding.shouldMatchFile("ActionWithInputsSharingTypeV3.kt")
     }
 
-    test("action binding generated to be used from a script") {
+    test("action binding generated on the client side") {
         // given
         val actionManifest =
             Metadata(
@@ -426,7 +426,7 @@ class GenerationTest : FunSpec({
             coords.generateBinding(
                 metadataRevision = FromLockfile,
                 metadata = actionManifest,
-                generateForScript = true,
+                clientType = ClientType.CLIENT_SIDE_GENERATION,
                 inputTypings =
                     Pair(
                         mapOf(


### PR DESCRIPTION
Part of #1318.

Thanks to this, we'll be able to define yet another mode, optimized for hosting the JARs with bindings by a dedicated service.