### PR TITLE
fix(ci): use Gradle encryption key for storing configuration cache

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -12,9 +12,12 @@ import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
 import io.github.typesafegithub.workflows.domain.RunnerType.Windows2022
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
+import io.github.typesafegithub.workflows.dsl.expressions.Contexts
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
 import io.github.typesafegithub.workflows.yaml.writeToFile
+
+val GRADLE_ENCRYPTION_KEY by Contexts.secrets
 
 @OptIn(ExperimentalClientSideBindings::class)
 workflow(
@@ -32,7 +35,9 @@ workflow(
         ) {
             uses(action = Checkout())
             setupJava()
-            uses(action = ActionsSetupGradle())
+            uses(action = ActionsSetupGradle(
+                cacheEncryptionKey = expr { GRADLE_ENCRYPTION_KEY },
+            ))
             run(
                 name = "Build",
                 command = "./gradlew build",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,8 @@ jobs:
         distribution: 'zulu'
     - id: 'step-2'
       uses: 'gradle/actions/setup-gradle@v3'
+      with:
+        cache-encryption-key: '${{ secrets.GRADLE_ENCRYPTION_KEY }}'
     - id: 'step-3'
       name: 'Build'
       run: './gradlew build'
@@ -58,6 +60,8 @@ jobs:
         distribution: 'zulu'
     - id: 'step-2'
       uses: 'gradle/actions/setup-gradle@v3'
+      with:
+        cache-encryption-key: '${{ secrets.GRADLE_ENCRYPTION_KEY }}'
     - id: 'step-3'
       name: 'Build'
       run: './gradlew build'


### PR DESCRIPTION
Per the docs: https://github.com/gradle/actions/tree/main/setup-gradle#saving-configuration-cache-data
This is the only missing element.