### PR TITLE
test(abg): update generated file in place

### DIFF
--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Utils.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/Utils.kt
@@ -3,39 +3,28 @@ package io.github.typesafegithub.workflows.actionbindinggenerator
 import io.github.typesafegithub.workflows.actionbindinggenerator.generation.ActionBinding
 import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
-import io.kotest.matchers.string.contain
 import java.nio.file.Paths
 
 fun ActionBinding.shouldMatchFile(path: String) {
-    val expectedFile =
+    val file =
         Paths.get("src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/$path")
             .toFile()
-    val actualFile = expectedFile.resolveSibling(expectedFile.nameWithoutExtension + "Actual.kt")
     val expectedContent =
         when {
-            expectedFile.canRead() -> expectedFile.readText().removeWindowsNewLines()
+            file.canRead() -> file.readText().removeWindowsNewLines()
             else -> ""
         }
     val actualContent = kotlinCode.removeWindowsNewLines()
 
     filePath shouldBe "github-workflows-kt/src/gen/kotlin/io/github/typesafegithub/workflows/actions/johnsmith/$path"
 
-    val packageName = "io.github.typesafegithub.workflows.actions.johnsmith"
-    expectedContent shouldNot contain("package $packageName.actual")
-
     if (System.getenv("GITHUB_ACTIONS") == "true") {
         actualContent shouldBe expectedContent
-    } else if (actualContent == expectedContent) {
-        actualFile.delete()
-    } else {
-        actualFile.writeText(
-            // change the package to avoid compilation errors because of duplicate classes / functions
-            actualContent.replace("package $packageName", "package $packageName.actual"),
-        )
+    } else if (actualContent != expectedContent) {
+        file.writeText(actualContent)
         fail(
-            "The Binding's kotlin code in ${actualFile.name} doesn't match ${expectedFile.name}\n" +
-                "See folder ${expectedFile.parentFile.canonicalPath}",
+            "The binding's Kotlin code in ${file.name} doesn't match the expected one.\n" +
+                "The file has been updated to match what's expected.",
         )
     }
 }


### PR DESCRIPTION
Before this change, if the generated Kotlin file didn't match the expected one, a new file was created under a different path. It was then hard to just accept the changes i.e. use what was actually produced as the expected file. This change makes the test edit the file in place.