### PR TITLE
fix(abg): correctly generate binding for JAR if some output present

### DIFF
--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
@@ -363,7 +363,7 @@ private fun TypeSpec.Builder.inheritsFromRegularAction(
                     OutputsBase
                 } else {
                     ClassName(
-                        if (clientType == ClientType.BUNDLED_WITH_LIB) {
+                        if (clientType != ClientType.CLIENT_SIDE_GENERATION) {
                             "io.github.typesafegithub.workflows.actions.${coords.owner.toKotlinPackageName()}"
                         } else {
                             ""

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionForGeneratedJar.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionForGeneratedJar.kt
@@ -104,8 +104,8 @@ public data class ActionForGeneratedJar private constructor(
      * version that the binding doesn't yet know about
      */
     public val _customVersion: String? = null,
-) : RegularAction<Action.Outputs>("john-smith", "action-for-generated-jar", _customVersion ?: "v3")
-        {
+) : RegularAction<ActionForGeneratedJar.Outputs>("john-smith", "action-for-generated-jar",
+        _customVersion ?: "v3") {
     public constructor(
         vararg pleaseUseNamedArguments: Unit,
         fooBar: String,
@@ -147,7 +147,7 @@ public data class ActionForGeneratedJar private constructor(
         ).toTypedArray()
     )
 
-    override fun buildOutputObject(stepId: String): Action.Outputs = Outputs(stepId)
+    override fun buildOutputObject(stepId: String): Outputs = Outputs(stepId)
 
     public sealed class Bin(
         public val stringValue: String,
@@ -207,5 +207,14 @@ public data class ActionForGeneratedJar private constructor(
         ) : ActionForGeneratedJar.MyInt(requestedValue)
 
         public object TheAnswer : ActionForGeneratedJar.MyInt(42)
+    }
+
+    public class Outputs(
+        stepId: String,
+    ) : Action.Outputs(stepId) {
+        /**
+         * Cool output!
+         */
+        public val bazGoo: String = "steps.$stepId.outputs.baz-goo"
     }
 }

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithAllTypesOfInputsV3.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithAllTypesOfInputsV3.kt
@@ -104,8 +104,8 @@ public data class ActionWithAllTypesOfInputsV3 private constructor(
      * version that the binding doesn't yet know about
      */
     public val _customVersion: String? = null,
-) : RegularAction<Action.Outputs>("john-smith", "action-with-all-types-of-inputs", _customVersion ?:
-        "v3") {
+) : RegularAction<ActionWithAllTypesOfInputsV3.Outputs>("john-smith",
+        "action-with-all-types-of-inputs", _customVersion ?: "v3") {
     public constructor(
         vararg pleaseUseNamedArguments: Unit,
         fooBar: String,
@@ -147,7 +147,7 @@ public data class ActionWithAllTypesOfInputsV3 private constructor(
         ).toTypedArray()
     )
 
-    override fun buildOutputObject(stepId: String): Action.Outputs = Outputs(stepId)
+    override fun buildOutputObject(stepId: String): Outputs = Outputs(stepId)
 
     public sealed class Bin(
         public val stringValue: String,
@@ -207,5 +207,14 @@ public data class ActionWithAllTypesOfInputsV3 private constructor(
         ) : ActionWithAllTypesOfInputsV3.MyInt(requestedValue)
 
         public object TheAnswer : ActionWithAllTypesOfInputsV3.MyInt(42)
+    }
+
+    public class Outputs(
+        stepId: String,
+    ) : Action.Outputs(stepId) {
+        /**
+         * Cool output!
+         */
+        public val bazGoo: String = "steps.$stepId.outputs.baz-goo"
     }
 }

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -18,7 +18,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class GenerationTest : FunSpec({
-    val actionManifestWithAllTypesOfInputs =
+    val actionManifestWithAllTypesOfInputsAndSomeOutput =
         Metadata(
             name = "Do something cool",
             description = "This is a test description that should be put in the KDoc comment for a class",
@@ -77,6 +77,10 @@ class GenerationTest : FunSpec({
                     "list-enums" to Input("List of enums"),
                     "list-int-special" to Input("List of integer with special values"),
                 ),
+            outputs =
+            mapOf(
+                "baz-goo" to Output(description = "Cool output!"),
+            ),
         )
     val typingsForAllTypesOfInputs =
         mapOf(
@@ -194,7 +198,7 @@ class GenerationTest : FunSpec({
         val binding =
             coords.generateBinding(
                 metadataRevision = FromLockfile,
-                metadata = actionManifestWithAllTypesOfInputs,
+                metadata = actionManifestWithAllTypesOfInputsAndSomeOutput,
                 inputTypings =
                     Pair(
                         typingsForAllTypesOfInputs,
@@ -507,7 +511,7 @@ class GenerationTest : FunSpec({
         val binding =
             coords.generateBinding(
                 metadataRevision = FromLockfile,
-                metadata = actionManifestWithAllTypesOfInputs,
+                metadata = actionManifestWithAllTypesOfInputsAndSomeOutput,
                 clientType = ClientType.VERSIONED_JAR,
                 inputTypings =
                     Pair(

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -78,9 +78,9 @@ class GenerationTest : FunSpec({
                     "list-int-special" to Input("List of integer with special values"),
                 ),
             outputs =
-            mapOf(
-                "baz-goo" to Output(description = "Cool output!"),
-            ),
+                mapOf(
+                    "baz-goo" to Output(description = "Cool output!"),
+                ),
         )
     val typingsForAllTypesOfInputs =
         mapOf(


### PR DESCRIPTION
It turned out that referring to some class in Kotlin Poet doesn't work correctly for the JAR consumer.