### PR TITLE
feat(server): provide checksums for Maven artifacts

### DIFF
--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/ModuleBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/ModuleBuilding.kt
@@ -4,8 +4,6 @@ internal fun buildModuleFile(
     owner: String,
     name: String,
     version: String,
-    size: Long,
-    md5Checksum: String,
 ): String =
     """
     {
@@ -40,8 +38,7 @@ internal fun buildModuleFile(
             {
               "name": "$name-$version.jar",
               "url": "$name-$version.jar",
-              "size": $size,
-              "md5": "$md5Checksum"
+              "size": 1
             }
           ]
         },

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/VersionArtifactsBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/VersionArtifactsBuilding.kt
@@ -24,14 +24,7 @@ data class JarArtifact(val data: ByteArray) : Artifact {
 fun ActionCoords.buildVersionArtifacts(): Map<String, Artifact> {
     val jar = buildJar(owner = owner, name = name.replace("__", "/"), version = version)
     val pom = buildPomFile(owner = owner, name = name.replace("__", "/"), version = version)
-    val module =
-        buildModuleFile(
-            owner = owner,
-            name = name.replace("__", "/"),
-            version = version,
-            size = jar.size.toLong(),
-            md5Checksum = jar.md5Checksum(),
-        )
+    val module = buildModuleFile(owner = owner, name = name.replace("__", "/"), version = version)
     return mapOf(
         "$name-$version.jar" to JarArtifact(jar),
         "$name-$version.jar.md5" to TextArtifact(jar.md5Checksum()),


### PR DESCRIPTION
Part of #1318.

Otherwise, Kotlin Script prints long warnings including scary stacktraces for each artifact, like:

```
[main] WARN org.jetbrains.kotlin.org.eclipse.aether.internal.impl.WarnChecksumPolicy - Could not validate integrity of download from http://localhost:8080/binding/actions/checkout/v4/checkout-v4.pom
org.jetbrains.kotlin.org.eclipse.aether.transfer.ChecksumFailureException: Checksum validation failed, no checksums available
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.AbstractChecksumPolicy.onNoMoreChecksums(AbstractChecksumPolicy.java:72)
	at org.jetbrains.kotlin.org.eclipse.aether.connector.basic.ChecksumValidator.validate(ChecksumValidator.java:126)
	at org.jetbrains.kotlin.org.eclipse.aether.connector.basic.BasicRepositoryConnector$GetTaskRunner.runTask(BasicRepositoryConnector.java:469)
	at org.jetbrains.kotlin.org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:383)
	at org.jetbrains.kotlin.org.eclipse.aether.util.concurrency.RunnableErrorForwarder.lambda$wrap$0(RunnableErrorForwarder.java:73)
	at org.jetbrains.kotlin.org.eclipse.aether.util.concurrency.RunnableErrorForwarder.accessor$RunnableErrorForwarder$lambda0(RunnableErrorForwarder.java)
	at org.jetbrains.kotlin.org.eclipse.aether.util.concurrency.RunnableErrorForwarder$$Lambda$0.run(Unknown Source)
	at org.jetbrains.kotlin.org.eclipse.aether.connector.basic.BasicRepositoryConnector$DirectExecutor.execute(BasicRepositoryConnector.java:635)
	at org.jetbrains.kotlin.org.eclipse.aether.connector.basic.BasicRepositoryConnector.get(BasicRepositoryConnector.java:280)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.DefaultArtifactResolver.performDownloads(DefaultArtifactResolver.java:595)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:478)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts(DefaultArtifactResolver.java:278)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact(DefaultArtifactResolver.java:255)
	at org.jetbrains.kotlin.org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom(DefaultArtifactDescriptorReader.java:240)
	at org.jetbrains.kotlin.org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor(DefaultArtifactDescriptorReader.java:171)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.collect.df.DfDependencyCollector.resolveCachedArtifactDescriptor(DfDependencyCollector.java:316)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.collect.df.DfDependencyCollector.getArtifactDescriptorResult(DfDependencyCollector.java:301)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.collect.df.DfDependencyCollector.processDependency(DfDependencyCollector.java:188)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.collect.df.DfDependencyCollector.processDependency(DfDependencyCollector.java:137)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.collect.df.DfDependencyCollector.process(DfDependencyCollector.java:125)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.collect.df.DfDependencyCollector.doCollectDependencies(DfDependencyCollector.java:107)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.collect.DependencyCollectorDelegate.collectDependencies(DependencyCollectorDelegate.java:247)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.collectDependencies(DefaultDependencyCollector.java:95)
	at org.jetbrains.kotlin.org.eclipse.aether.internal.impl.DefaultRepositorySystem.collectDependencies(DefaultRepositorySystem.java:327)
	at kotlin.script.experimental.dependencies.maven.impl.AetherResolveSession$resolveTree$2.invoke(aether.kt:210)
	at kotlin.script.experimental.dependencies.maven.impl.AetherResolveSession$resolveTree$2.invoke(aether.kt:206)
	at kotlin.script.experimental.dependencies.maven.impl.AetherResolveSession.fetch(aether.kt:278)
	at kotlin.script.experimental.dependencies.maven.impl.AetherResolveSession.resolveTree(aether.kt:206)
	at kotlin.script.experimental.dependencies.maven.impl.AetherResolveSession.resolve(aether.kt:156)
	at kotlin.script.experimental.dependencies.maven.MavenDependenciesResolver.resolve(MavenDependenciesResolver.kt:81)
	at kotlin.script.experimental.dependencies.CompoundDependenciesResolver.resolve(CompoundDependenciesResolver.kt:97)
	at kotlin.script.experimental.dependencies.ExternalDependenciesResolver.resolve$suspendImpl(ExternalDependenciesResolver.kt:35)
	at kotlin.script.experimental.dependencies.ExternalDependenciesResolver.resolve(ExternalDependenciesResolver.kt)
	at kotlin.script.experimental.dependencies.AnnotationsKt.resolveFromScriptSourceAnnotations(annotations.kt:70)
	at org.jetbrains.kotlin.mainKts.MainKtsConfigurator$processAnnotations$resolveResult$1.invokeSuspend(scriptDef.kt:201)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlin.coroutines.ContinuationKt.startCoroutine(Continuation.kt:115)
	at kotlin.script.experimental.impl.RunSuspendKt.internalScriptingRunSuspend(runSuspend.kt:19)
	at org.jetbrains.kotlin.mainKts.MainKtsConfigurator.processAnnotations(scriptDef.kt:200)
	at org.jetbrains.kotlin.mainKts.MainKtsConfigurator.invoke(scriptDef.kt:153)
	at org.jetbrains.kotlin.mainKts.MainKtsConfigurator.invoke(scriptDef.kt:149)
	at kotlin.script.experimental.api.ScriptCompilationKt.refineOnAnnotations(scriptCompilation.kt:302)
	at org.jetbrains.kotlin.scripting.resolve.RefineCompilationConfigurationKt.refineScriptCompilationConfiguration(refineCompilationConfiguration.kt:250)
	at org.jetbrains.kotlin.scripting.compiler.plugin.definitions.CliScriptDependenciesProvider.calculateRefinedConfiguration(CliScriptDependenciesProvider.kt:44)
	at org.jetbrains.kotlin.scripting.compiler.plugin.definitions.CliScriptDependenciesProvider.getScriptConfigurationResult(CliScriptDependenciesProvider.kt:31)
	at org.jetbrains.kotlin.scripting.compiler.plugin.dependencies.ScriptsCompilationDependenciesKt.collectScriptsCompilationDependencies(ScriptsCompilationDependencies.kt:55)
	at org.jetbrains.kotlin.scripting.compiler.plugin.impl.CompilationContextKt.collectRefinedSourcesAndUpdateEnvironment(compilationContext.kt:329)
	at org.jetbrains.kotlin.scripting.compiler.plugin.impl.ScriptJvmCompilerImplsKt.compileImpl(ScriptJvmCompilerImpls.kt:140)
	at org.jetbrains.kotlin.scripting.compiler.plugin.impl.ScriptJvmCompilerImplsKt.access$compileImpl(ScriptJvmCompilerImpls.kt:1)
	at org.jetbrains.kotlin.scripting.compiler.plugin.impl.ScriptJvmCompilerFromEnvironment$compile$1$1.invoke(ScriptJvmCompilerImpls.kt:95)
	at org.jetbrains.kotlin.scripting.compiler.plugin.impl.ScriptJvmCompilerFromEnvironment$compile$1$1.invoke(ScriptJvmCompilerImpls.kt:83)
	at org.jetbrains.kotlin.scripting.compiler.plugin.impl.ScriptJvmCompilerImplsKt.withScriptCompilationCache(ScriptJvmCompilerImpls.kt:116)
	at org.jetbrains.kotlin.scripting.compiler.plugin.impl.ScriptJvmCompilerImplsKt.access$withScriptCompilationCache(ScriptJvmCompilerImpls.kt:1)
	at org.jetbrains.kotlin.scripting.compiler.plugin.impl.ScriptJvmCompilerFromEnvironment.compile(ScriptJvmCompilerImpls.kt:83)
	at org.jetbrains.kotlin.scripting.compiler.plugin.AbstractScriptEvaluationExtension$doEval$1.invokeSuspend(AbstractScriptEvaluationExtension.kt:136)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlin.coroutines.ContinuationKt.startCoroutine(Continuation.kt:115)
	at kotlin.script.experimental.impl.RunSuspendKt.internalScriptingRunSuspend(runSuspend.kt:19)
	at org.jetbrains.kotlin.scripting.compiler.plugin.AbstractScriptEvaluationExtension.doEval(AbstractScriptEvaluationExtension.kt:135)
	at org.jetbrains.kotlin.scripting.compiler.plugin.AbstractScriptEvaluationExtension.eval(AbstractScriptEvaluationExtension.kt:122)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:111)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:50)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:104)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:48)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:101)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:79)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:43)
	at org.jetbrains.kotlin.cli.common.CLITool$Companion.doMainNoExit(CLITool.kt:180)
	at org.jetbrains.kotlin.cli.common.CLITool$Companion.doMainNoExit$default(CLITool.kt:175)
	at org.jetbrains.kotlin.cli.common.CLITool$Companion.doMain(CLITool.kt:167)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler$Companion.main(K2JVMCompiler.kt:250)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.main(K2JVMCompiler.kt)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jetbrains.kotlin.runner.RunnerWithCompiler.runCompiler(runners.kt:116)
	at org.jetbrains.kotlin.runner.ScriptRunner.run(runners.kt:157)
	at org.jetbrains.kotlin.runner.Main.run(Main.kt:194)
	at org.jetbrains.kotlin.runner.Main.main(Main.kt:204)
```