### PR TITLE
feat(server): serve artifacts for specific versions

### DIFF
--- a/.github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts
+++ b/.github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts
@@ -10,8 +10,13 @@
 // Nested action.
 @file:DependsOn("gradle:actions__setup-gradle:v3")
 
+// Using specific version.
+@file:DependsOn("actions:cache:v3.3.3")
+
+import io.github.typesafegithub.workflows.actions.actions.Cache
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
 
 println(Checkout())
 println(ActionsSetupGradle())
+println(Cache(path = listOf("some-path"), key = "some-key"))

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
@@ -72,8 +72,10 @@ public fun ActionCoords.generateBinding(
     inputTypings: Pair<Map<String, Typing>, TypingActualSource?>? = null,
     clientType: ClientType = ClientType.BUNDLED_WITH_LIB,
 ): ActionBinding? {
-    require(this.version.removePrefix("v").toIntOrNull() != null) {
-        "Only major versions are supported, and '${this.version}' was given!"
+    if (clientType == ClientType.BUNDLED_WITH_LIB) {
+        require(this.version.removePrefix("v").toIntOrNull() != null) {
+            "Only major versions are supported, and '${this.version}' was given!"
+        }
     }
     val metadataResolved = metadata ?: this.fetchMetadata(metadataRevision) ?: return null
     val metadataProcessed = metadataResolved.removeDeprecatedInputsIfNameClash()

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
@@ -26,7 +26,7 @@ internal fun ActionCoords.provideTypes(
 ): Pair<Map<String, Typing>, TypingActualSource?> =
     (
         this.fetchTypingMetadata(metadataRevision, fetchUri)
-            ?: this.fetchFromTypingsFromCatalog(fetchUri)
+            ?: this.toMajorVersion().fetchFromTypingsFromCatalog(fetchUri)
     )
         ?.let { Pair(it.first.toTypesMap(), it.second) }
         ?: Pair(emptyMap(), null)
@@ -124,6 +124,8 @@ internal fun ActionTypes.toTypesMap(): Map<String, Typing> {
         value.toTyping(key)
     }
 }
+
+private fun ActionCoords.toMajorVersion(): ActionCoords = this.copy(version = this.version.substringBefore("."))
 
 private fun ActionType.toTyping(fieldName: String): Typing =
     when (this.type) {


### PR DESCRIPTION
Part of #1318.

It doesn't yet support enumerating specific versions for e.g. dependency
updating bots.
