### PR TITLE
test(server): ensure maven-metadata.xml returns existing version

### DIFF
--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -86,11 +86,11 @@ workflow(
 
         run(
             name = "Fetch maven-metadata.xml for top-level action",
-            command = "curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml",
+            command = "curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml | grep '<version>v4</version>'",
         )
         run(
             name = "Fetch maven-metadata.xml for nested action",
-            command = "curl --fail http://localhost:8080/binding/actions/cache__save/maven-metadata.xml",
+            command = "curl --fail http://localhost:8080/binding/actions/cache__save/maven-metadata.xml | grep '<version>v4</version>'",
         )
     }
 

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -47,10 +47,10 @@ jobs:
         .github/workflows/test-script-consuming-jit-bindings.main.kts
     - id: 'step-5'
       name: 'Fetch maven-metadata.xml for top-level action'
-      run: 'curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml'
+      run: 'curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
     - id: 'step-6'
       name: 'Fetch maven-metadata.xml for nested action'
-      run: 'curl --fail http://localhost:8080/binding/actions/cache__save/maven-metadata.xml'
+      run: 'curl --fail http://localhost:8080/binding/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
   deploy:
     name: 'Deploy to DockerHub'
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
It makes the test catch a case when the endpoint returns HTTP 200, but the contents is malformed.