### PR TITLE
refactor: move Version to shared-internal

### DIFF
--- a/automation/code-generator/build.gradle.kts
+++ b/automation/code-generator/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation("io.arrow-kt:arrow-fx-coroutines:1.2.4")
 
     implementation(projects.actionBindingGenerator)
+    implementation(projects.sharedInternal)
 
     testImplementation(projects.githubWorkflowsKt)
 }

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/ActionsDocsGeneration.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/ActionsDocsGeneration.kt
@@ -4,7 +4,7 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCo
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
 import io.github.typesafegithub.workflows.actionbindinggenerator.generation.ActionBinding
 import io.github.typesafegithub.workflows.codegenerator.model.ActionBindingRequest
-import io.github.typesafegithub.workflows.codegenerator.model.Version
+import io.github.typesafegithub.workflows.shared.internal.model.Version
 import java.nio.file.Paths
 
 internal fun generateListOfBindingsForDocs(requestsAndBindings: List<Pair<ActionBindingRequest, ActionBinding>>) {

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/AddDeprecationInfo.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/AddDeprecationInfo.kt
@@ -1,7 +1,7 @@
 package io.github.typesafegithub.workflows.codegenerator
 
 import io.github.typesafegithub.workflows.codegenerator.model.ActionBindingRequest
-import io.github.typesafegithub.workflows.codegenerator.model.Version
+import io.github.typesafegithub.workflows.shared.internal.model.Version
 
 fun List<ActionBindingRequest>.addDeprecationInfo(): List<ActionBindingRequest> =
     this.groupBy { "${it.actionCoords.owner}/${it.actionCoords.name}" }

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/Http.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/Http.kt
@@ -1,7 +1,7 @@
 package io.github.typesafegithub.workflows.codegenerator.versions
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
-import io.github.typesafegithub.workflows.codegenerator.model.Version
+import io.github.typesafegithub.workflows.shared.internal.model.Version
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/SuggestVersions.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/SuggestVersions.kt
@@ -9,7 +9,7 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.prettyPr
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.Metadata
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.fetchMetadata
 import io.github.typesafegithub.workflows.codegenerator.bindingsToGenerate
-import io.github.typesafegithub.workflows.codegenerator.model.Version
+import io.github.typesafegithub.workflows.shared.internal.model.Version
 import java.io.File
 
 /**

--- a/automation/code-generator/src/test/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/SuggestVersionsTest.kt
+++ b/automation/code-generator/src/test/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/SuggestVersionsTest.kt
@@ -5,7 +5,7 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.Metadata
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.Input
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.Metadata
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.Output
-import io.github.typesafegithub.workflows.codegenerator.model.Version
+import io.github.typesafegithub.workflows.shared.internal.model.Version
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.Table2

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/model/Version.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/model/Version.kt
@@ -1,4 +1,4 @@
-package io.github.typesafegithub.workflows.codegenerator.model
+package io.github.typesafegithub.workflows.shared.internal.model
 
 data class Version(val version: String) : Comparable<Version> {
     val input: String = version.removePrefix("v").removePrefix("V")


### PR DESCRIPTION
A step towards having fetching available action versions in shared-internal.