### PR TITLE
refactor: move getGithubToken to shared-internal

### DIFF
--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/updating/CreateActionUpdatePRs.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/updating/CreateActionUpdatePRs.kt
@@ -10,9 +10,9 @@ import io.github.typesafegithub.workflows.codegenerator.bindingsToGenerate
 import io.github.typesafegithub.workflows.codegenerator.model.ActionBindingRequest
 import io.github.typesafegithub.workflows.codegenerator.versions.GithubRef
 import io.github.typesafegithub.workflows.codegenerator.versions.GithubTag
-import io.github.typesafegithub.workflows.codegenerator.versions.getGithubToken
 import io.github.typesafegithub.workflows.codegenerator.versions.httpClient
 import io.github.typesafegithub.workflows.codegenerator.versions.json
+import io.github.typesafegithub.workflows.shared.internal.getGithubToken
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/Http.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/Http.kt
@@ -18,16 +18,6 @@ val ActionCoords.apiTagsUrl: String
 val ActionCoords.apiBranchesUrl: String
     get() = "https://api.github.com/repos/$owner/$name/git/matching-refs/heads/v"
 
-fun getGithubToken(): String =
-    System.getenv("GITHUB_TOKEN")
-        ?: error(
-            """
-            Missing environment variable export GITHUB_TOKEN=token
-            Create a personal token at https://github.com/settings/tokens
-            The token needs to have public_repo scope.
-            """.trimIndent(),
-        )
-
 @Serializable
 data class GithubRef(
     val ref: String,

--- a/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/SuggestVersions.kt
+++ b/automation/code-generator/src/main/kotlin/io/github/typesafegithub/workflows/codegenerator/versions/SuggestVersions.kt
@@ -9,6 +9,7 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.prettyPr
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.Metadata
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.fetchMetadata
 import io.github.typesafegithub.workflows.codegenerator.bindingsToGenerate
+import io.github.typesafegithub.workflows.shared.internal.getGithubToken
 import io.github.typesafegithub.workflows.shared.internal.model.Version
 import java.io.File
 

--- a/jit-binding-server/build.gradle.kts
+++ b/jit-binding-server/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:1.5.6")
 
     implementation(projects.mavenBindingBuilder)
+    implementation(projects.sharedInternal)
 }
 
 application {

--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
@@ -8,6 +8,7 @@ import io.github.typesafegithub.workflows.mavenbinding.JarArtifact
 import io.github.typesafegithub.workflows.mavenbinding.TextArtifact
 import io.github.typesafegithub.workflows.mavenbinding.buildPackageArtifacts
 import io.github.typesafegithub.workflows.mavenbinding.buildVersionArtifacts
+import io.github.typesafegithub.workflows.shared.internal.getGithubToken
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
@@ -110,7 +111,7 @@ fun main() {
                             name = name,
                             version = "irrelevant",
                         )
-                    val bindingArtifacts = actionCoords.buildPackageArtifacts(githubToken = System.getenv("GITHUB_TOKEN"))
+                    val bindingArtifacts = actionCoords.buildPackageArtifacts(githubToken = getGithubToken())
                     if (file in bindingArtifacts) {
                         when (val artifact = bindingArtifacts[file]) {
                             is String -> call.respondText(artifact)

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
@@ -1,0 +1,11 @@
+package io.github.typesafegithub.workflows.shared.internal
+
+fun getGithubToken(): String =
+    System.getenv("GITHUB_TOKEN")
+        ?: error(
+            """
+            Missing environment variable export GITHUB_TOKEN=token
+            Create a personal token at https://github.com/settings/tokens
+            The token needs to have public_repo scope.
+            """.trimIndent(),
+        )


### PR DESCRIPTION
A step towards having fetching available action versions in shared-internal.