### PR TITLE
chore: skip signing for snapshot versions

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/publishing.gradle.kts
@@ -64,13 +64,10 @@ publishing {
 }
 
 signing {
-    val isSnapshotVersion = project.version.toString().endsWith("-SNAPSHOT")
     setRequired({
-        !isSnapshotVersion && gradle.taskGraph.hasTask("publish")
+        !project.version.toString().endsWith("-SNAPSHOT")
     })
-    if (!isSnapshotVersion) {
-        sign(publishing.publications["mavenJava"])
-    }
+    sign(publishing.publications["mavenJava"])
 
     val signingKey = System.getenv("SIGNING_KEY")
     val signingPassword = System.getenv("SIGNING_PASSWORD")

--- a/buildSrc/src/main/kotlin/buildsrc/convention/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/publishing.gradle.kts
@@ -64,7 +64,11 @@ publishing {
 }
 
 signing {
-    if (!project.version.toString().endsWith("-SNAPSHOT")) {
+    val isSnapshotVersion = project.version.toString().endsWith("-SNAPSHOT")
+    setRequired({
+        !isSnapshotVersion && gradle.taskGraph.hasTask("publish")
+    })
+    if (!isSnapshotVersion) {
         sign(publishing.publications["mavenJava"])
     }
 


### PR DESCRIPTION
this makes it so you can run `publishToMavenLocal` without signing
even when `sign()` is not being called the plugin is stil ldoing something and erroring when the environment is not set up correctly

the issue turns out to be `project.version` not being defined until later
 
~~the task being used as a condition is probably not correct and this can be adjusted, we could instead check for the absence of `publishToMavenLocal` ?~~
we don't need this check anymore