### PR TITLE
chore: remove signing keys from snapshot publishing job

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -56,8 +56,6 @@ workflow(
         runsOn = UbuntuLatest,
         condition = expr { "${github.ref} == 'refs/heads/main'" },
         env = linkedMapOf(
-            "SIGNING_KEY" to expr("secrets.SIGNING_KEY"),
-            "SIGNING_PASSWORD" to expr("secrets.SIGNING_PASSWORD"),
             "ORG_GRADLE_PROJECT_sonatypeUsername" to expr("secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME"),
             "ORG_GRADLE_PROJECT_sonatypePassword" to expr("secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD"),
         ),

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,8 +68,6 @@ jobs:
     needs:
     - 'check_yaml_consistency'
     env:
-      SIGNING_KEY: '${{ secrets.SIGNING_KEY }}'
-      SIGNING_PASSWORD: '${{ secrets.SIGNING_PASSWORD }}'
       ORG_GRADLE_PROJECT_sonatypeUsername: '${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}'
       ORG_GRADLE_PROJECT_sonatypePassword: '${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}'
     if: '${{ github.ref == ''refs/heads/main'' }}'


### PR DESCRIPTION
It's simply not needed as signing doesn't happen there.