### PR TITLE
ci: add end-to-end tests workflow

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -98,6 +98,10 @@ workflow(
             command = """
             find -name *.main.kts -print0 | while read -d ${'$'}'\0' file
             do
+                if [ "${'$'}file" = ".github/workflows/end-to-end-tests.main.kts" ]; then
+                    continue
+                fi
+
                 echo "Compiling ${'$'}file..."
                 kotlinc -Werror -Xallow-any-scripts-in-source-roots "${'$'}file"
             done
@@ -125,6 +129,10 @@ workflow(
             command = """
             find -name "*.main.kts" -print0 | while read -d ${'$'}'\0' file
             do
+                if [ "${'$'}file" = ".github/workflows/end-to-end-tests.main.kts" ]; then
+                    continue
+                fi
+
                 if [ -x "${'$'}file" ]; then
                     echo "Regenerating ${'$'}file..."
                     (${'$'}file)

--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -98,7 +98,7 @@ workflow(
             command = """
             find -name *.main.kts -print0 | while read -d ${'$'}'\0' file
             do
-                if [ "${'$'}file" = ".github/workflows/end-to-end-tests.main.kts" ]; then
+                if [ "${'$'}file" = "./.github/workflows/end-to-end-tests.main.kts" ]; then
                     continue
                 fi
 
@@ -129,7 +129,7 @@ workflow(
             command = """
             find -name "*.main.kts" -print0 | while read -d ${'$'}'\0' file
             do
-                if [ "${'$'}file" = ".github/workflows/end-to-end-tests.main.kts" ]; then
+                if [ "${'$'}file" = "./.github/workflows/end-to-end-tests.main.kts" ]; then
                     continue
                 fi
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,6 +125,10 @@ jobs:
       run: |-
         find -name *.main.kts -print0 | while read -d $'\0' file
         do
+            if [ "$file" = ".github/workflows/end-to-end-tests.main.kts" ]; then
+                continue
+            fi
+
             echo "Compiling $file..."
             kotlinc -Werror -Xallow-any-scripts-in-source-roots "$file"
         done
@@ -150,6 +154,10 @@ jobs:
       run: |-
         find -name "*.main.kts" -print0 | while read -d $'\0' file
         do
+            if [ "$file" = ".github/workflows/end-to-end-tests.main.kts" ]; then
+                continue
+            fi
+
             if [ -x "$file" ]; then
                 echo "Regenerating $file..."
                 ($file)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,7 +125,7 @@ jobs:
       run: |-
         find -name *.main.kts -print0 | while read -d $'\0' file
         do
-            if [ "$file" = ".github/workflows/end-to-end-tests.main.kts" ]; then
+            if [ "$file" = "./.github/workflows/end-to-end-tests.main.kts" ]; then
                 continue
             fi
 
@@ -154,7 +154,7 @@ jobs:
       run: |-
         find -name "*.main.kts" -print0 | while read -d $'\0' file
         do
-            if [ "$file" = ".github/workflows/end-to-end-tests.main.kts" ]; then
+            if [ "$file" = "./.github/workflows/end-to-end-tests.main.kts" ]; then
                 continue
             fi
 

--- a/.github/workflows/end-to-end-tests.main.kts
+++ b/.github/workflows/end-to-end-tests.main.kts
@@ -1,0 +1,48 @@
+#!/usr/bin/env kotlin
+@file:Repository("file://~/.m2/repository/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.14.1-SNAPSHOT")
+@file:Repository("https://github-workflows-kt-bindings.colman.com.br/binding/")
+@file:DependsOn("actions:checkout:v4")
+@file:DependsOn("actions:setup-java:v4")
+@file:DependsOn("gradle:actions__setup-gradle:v3")
+
+import io.github.typesafegithub.workflows.actions.actions.Checkout
+import io.github.typesafegithub.workflows.actions.actions.SetupJava
+import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
+import io.github.typesafegithub.workflows.domain.RunnerType
+import io.github.typesafegithub.workflows.domain.triggers.PullRequest
+import io.github.typesafegithub.workflows.domain.triggers.Push
+import io.github.typesafegithub.workflows.dsl.workflow
+import io.github.typesafegithub.workflows.yaml.writeToFile
+
+workflow(
+    name = "End-to-end tests",
+    on = listOf(
+        Push(branches = listOf("main")),
+        PullRequest(),
+    ),
+    yamlConsistencyJobAdditionalSteps = {
+        uses(
+            name = "Set up JDK",
+            action = SetupJava(
+                javaVersion = "11",
+                distribution = SetupJava.Distribution.Zulu,
+            ),
+        )
+        uses(action = ActionsSetupGradle(generateJobSummary = false))
+        run(
+            name = "Publish to Maven local",
+            command = "./gradlew publishToMavenLocal",
+        )
+    },
+    sourceFile = __FILE__.toPath(),
+) {
+    job(
+        id = "main-job",
+        name = "Main job",
+        runsOn = RunnerType.UbuntuLatest,
+    ) {
+        uses(action = Checkout())
+        run(command = "echo 'Hello world!'")
+    }
+}.writeToFile()

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -1,0 +1,47 @@
+# This file was generated using Kotlin DSL (.github/workflows/end-to-end-tests.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/typesafegithub/github-workflows-kt
+
+name: 'End-to-end tests'
+on:
+  push:
+    branches:
+    - 'main'
+  pull_request: {}
+jobs:
+  check_yaml_consistency:
+    name: 'Check YAML consistency'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - id: 'step-0'
+      name: 'Check out'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      name: 'Set up JDK'
+      uses: 'actions/setup-java@v4'
+      with:
+        java-version: '11'
+        distribution: 'zulu'
+    - id: 'step-2'
+      uses: 'gradle/actions/setup-gradle@v3'
+      with:
+        generate-job-summary: 'false'
+    - id: 'step-3'
+      name: 'Publish to Maven local'
+      run: './gradlew publishToMavenLocal'
+    - id: 'step-4'
+      name: 'Execute script'
+      run: 'rm ''.github/workflows/end-to-end-tests.yaml'' && ''.github/workflows/end-to-end-tests.main.kts'''
+    - id: 'step-5'
+      name: 'Consistency check'
+      run: 'git diff --exit-code ''.github/workflows/end-to-end-tests.yaml'''
+  main-job:
+    name: 'Main job'
+    runs-on: 'ubuntu-latest'
+    needs:
+    - 'check_yaml_consistency'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      run: 'echo ''Hello world!'''

--- a/github-workflows-kt/build.gradle.kts
+++ b/github-workflows-kt/build.gradle.kts
@@ -86,6 +86,10 @@ val validateDuplicatedVersion by tasks.creating<Task> {
             rootDir.resolve("github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/docsnippets/GettingStartedSnippets.kt").readText()
                 .contains("\"io.github.typesafegithub:github-workflows-kt:$version\"")
         ) { "Library version stated in github-workflows-kt/src/test/.../GettingStarted.kt should be equal to $version!" }
+        require(
+            rootDir.resolve(".github/workflows/end-to-end-tests.main.kts").readText()
+                .contains("\"io.github.typesafegithub:github-workflows-kt:$version\"")
+        ) { "Library version stated in end-to-end-tests.main.kts should be equal to $version!" }
     }
 }
 


### PR DESCRIPTION
The main goal of this workflow is to use freshly build library from
a given commit inside a workflow ran from a Kotlin script.
