### PR TITLE
fix(dsl): make 'after' github context field optional

### DIFF
--- a/github-workflows-kt/api/github-workflows-kt.api
+++ b/github-workflows-kt/api/github-workflows-kt.api
@@ -654,7 +654,9 @@ public final class io/github/typesafegithub/workflows/domain/contexts/GithubCont
 
 public final class io/github/typesafegithub/workflows/domain/contexts/GithubContextEvent {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/contexts/GithubContextEvent$Companion;
+	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/contexts/GithubContextEvent;
 	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/contexts/GithubContextEvent;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/contexts/GithubContextEvent;

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/contexts/GithubContext.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/contexts/GithubContext.kt
@@ -15,5 +15,5 @@ public data class GithubContext(
 
 @Serializable
 public data class GithubContextEvent(
-    val after: String?,
+    val after: String? = null,
 )


### PR DESCRIPTION
There was no default value assigned, so in fact it was required in the
JSON.
