### PR TITLE
chore(dsl)!: remove toYaml()

### DIFF
--- a/.github/workflows/end-to-end-tests.main.kts
+++ b/.github/workflows/end-to-end-tests.main.kts
@@ -1,7 +1,7 @@
 #!/usr/bin/env kotlin
 @file:Repository("file://~/.m2/repository/")
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.15.1-SNAPSHOT")
-@file:DependsOn("io.github.typesafegithub:action-updates-checker:1.15.1-SNAPSHOT")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.0.0-SNAPSHOT")
+@file:DependsOn("io.github.typesafegithub:action-updates-checker:2.0.0-SNAPSHOT")
 @file:Repository("https://github-workflows-kt-bindings.colman.com.br/binding/")
 @file:DependsOn("actions:checkout:v4")
 @file:DependsOn("actions:github-script:v7")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.typesafegithub"
-version = "1.15.1-SNAPSHOT"
+version = "2.0.0-SNAPSHOT"
 
 nexusPublishing {
     repositories {

--- a/docs/user-guide/getting_started.md
+++ b/docs/user-guide/getting_started.md
@@ -28,10 +28,6 @@ names with your own.
    You'll see it in a moment in the generated file. What's written to the `workflow` variable is an object of type
    `io.github.typesafegithub.workflows.domain.Workflow`, it's not a YAML yet. However, a call to `writeToFile()`
    extension function does the final piece of job.  
-   Alternatively, apart from `writeToFile()` which puts the string straight into the file under path inferred by the
-   library or name overridden with `targetFileName` workflow argument, there's also `toYaml()` which doesn't touch
-   any files, it just returns a string with the YAML. It may come in handy when more control over the YAML is needed,
-   e.g. to do some post-processing.
 4. Generate the YAML by calling the above script:
    ```
    .github/workflows/hello_world_workflow.main.kts

--- a/github-workflows-kt/api/github-workflows-kt.api
+++ b/github-workflows-kt/api/github-workflows-kt.api
@@ -3148,8 +3148,6 @@ public final class io/github/typesafegithub/workflows/yaml/Preamble$WithOriginal
 }
 
 public final class io/github/typesafegithub/workflows/yaml/ToYamlKt {
-	public static final fun toYaml (Lio/github/typesafegithub/workflows/domain/Workflow;ZLjava/nio/file/Path;Lio/github/typesafegithub/workflows/yaml/Preamble;)Ljava/lang/String;
-	public static synthetic fun toYaml$default (Lio/github/typesafegithub/workflows/domain/Workflow;ZLjava/nio/file/Path;Lio/github/typesafegithub/workflows/yaml/Preamble;ILjava/lang/Object;)Ljava/lang/String;
 	public static final fun writeToFile (Lio/github/typesafegithub/workflows/domain/Workflow;ZLjava/nio/file/Path;Lio/github/typesafegithub/workflows/yaml/Preamble;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun writeToFile$default (Lio/github/typesafegithub/workflows/domain/Workflow;ZLjava/nio/file/Path;Lio/github/typesafegithub/workflows/yaml/Preamble;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/docsnippets/GettingStartedSnippets.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/docsnippets/GettingStartedSnippets.kt
@@ -18,7 +18,7 @@ class GettingStartedSnippets : FunSpec({
         // --8<-- [start:getting-started-1]
         #!/usr/bin/env kotlin
 
-        @file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.15.1-SNAPSHOT")
+        @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.0.0-SNAPSHOT")
 
         // --8<-- [end:getting-started-1]
          */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,4 +59,4 @@ nav:
   - Projects using this library: 'projects-using-this-library.md'
 
 extra:
-  version: 1.15.1-SNAPSHOT
+  version: 2.0.0-SNAPSHOT


### PR DESCRIPTION
Part of #1208.

There's going to be a single way of writing the YAML to file. In practice, it turned out that `toYaml()` is used very sparingly.
