### PR TITLE
feat(dsl): allow writing workflow to string

### DIFF
--- a/github-workflows-kt/api/github-workflows-kt.api
+++ b/github-workflows-kt/api/github-workflows-kt.api
@@ -3174,6 +3174,11 @@ public final class io/github/typesafegithub/workflows/yaml/Preamble$WithOriginal
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class io/github/typesafegithub/workflows/yaml/ToYamlKt {
+	public static final fun generateYaml (Lio/github/typesafegithub/workflows/domain/Workflow;Ljava/nio/file/Path;Lio/github/typesafegithub/workflows/yaml/Preamble;)Ljava/lang/String;
+	public static synthetic fun generateYaml$default (Lio/github/typesafegithub/workflows/domain/Workflow;Ljava/nio/file/Path;Lio/github/typesafegithub/workflows/yaml/Preamble;ILjava/lang/Object;)Ljava/lang/String;
+}
+
 public final class io/github/typesafegithub/workflows/yaml/TriggersToYamlKt {
 	public static final fun toMap (Lio/github/typesafegithub/workflows/domain/triggers/Trigger;)Ljava/util/Map;
 	public static final fun triggerName (Lio/github/typesafegithub/workflows/domain/triggers/Trigger;)Ljava/lang/String;

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/dsl/WorkflowBuilder.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/dsl/WorkflowBuilder.kt
@@ -163,6 +163,12 @@ public fun Workflow.toBuilder(): WorkflowBuilder =
         _customArguments = _customArguments,
     )
 
+/**
+ * A DSL function that models the top-level parts of the GitHub Actions workflow.
+ *
+ * @param targetFileName Name of the produced YAML file inside the `.github/workflows` directory. If set to `null`,
+ * writing to file is disabled.
+ */
 @Suppress("LongParameterList", "FunctionParameterNaming")
 public fun workflow(
     @Suppress("UNUSED_PARAMETER")
@@ -215,11 +221,13 @@ public fun workflow(
 
     return workflowBuilder.build()
         .also {
-            it.writeToFile(
-                gitRootDir = gitRootDir,
-                preamble = preamble,
-                getenv = getenv,
-            )
+            if (targetFileName != null) {
+                it.writeToFile(
+                    gitRootDir = gitRootDir,
+                    preamble = preamble,
+                    getenv = getenv,
+                )
+            }
         }
 }
 


### PR DESCRIPTION
Closes #1468.

It was possible in 1.x, and this possibility was removed because I assumed no one needs it. It turns out that some users prefer writing the YAML themselves. This simple backward-compatible change gives more freedom to the users of the lib.