### PR TITLE
refactor(server): extract handlers in routing to functions

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
@@ -16,6 +16,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.response.respondBytes
 import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.head
 import io.ktor.server.routing.route
@@ -30,96 +31,13 @@ fun main() {
 
     embeddedServer(Netty, port = 8080) {
         routing {
-            route("/binding/{owner}/{name}/{version}/{file}") {
-                get {
-                    val owner = call.parameters["owner"]!!
-                    val name = call.parameters["name"]!!
-                    val version = call.parameters["version"]!!
-                    val actionCoords =
-                        ActionCoords(
-                            owner = owner,
-                            name = name,
-                            version = version,
-                        )
-                    println("➡️ Requesting ${actionCoords.prettyPrint}")
-                    val bindingArtifacts =
-                        bindingsCache.get(actionCoords) {
-                            actionCoords.buildVersionArtifacts()?.let {
-                                Result.success(it)
-                            } ?: Result.failure(object : Throwable() {})
-                        }.getOrNull()
-
-                    if (bindingArtifacts == null) {
-                        call.respondText("Not found", status = HttpStatusCode.NotFound)
-                        return@get
-                    }
-
-                    val file = call.parameters["file"]!!
-                    if (file in bindingArtifacts) {
-                        when (val artifact = bindingArtifacts[file]) {
-                            is TextArtifact -> call.respondText(artifact.data)
-                            is JarArtifact ->
-                                call.respondBytes(
-                                    bytes = artifact.data,
-                                    contentType = ContentType.parse("application/java-archive"),
-                                )
-                            else -> call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
-                        }
-                    } else {
-                        call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
-                    }
+            route("/binding") {
+                route("{owner}/{name}/{version}/{file}") {
+                    artifact(bindingsCache)
                 }
 
-                head {
-                    val owner = call.parameters["owner"]!!
-                    val name = call.parameters["name"]!!
-                    val version = call.parameters["version"]!!
-                    val file = call.parameters["file"]!!
-                    val actionCoords =
-                        ActionCoords(
-                            owner = owner,
-                            name = name,
-                            version = version,
-                        )
-                    val bindingArtifacts =
-                        bindingsCache.get(actionCoords) {
-                            actionCoords.buildVersionArtifacts()?.let {
-                                Result.success(it)
-                            } ?: Result.failure(object : Throwable() {})
-                        }.getOrNull()
-
-                    if (bindingArtifacts == null) {
-                        call.respondText("Not found", status = HttpStatusCode.NotFound)
-                        return@head
-                    }
-                    if (file in bindingArtifacts) {
-                        call.respondText("Exists", status = HttpStatusCode.OK)
-                    } else {
-                        call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
-                    }
-                }
-            }
-
-            route("/binding/{owner}/{name}/{file}") {
-                get {
-                    val owner = call.parameters["owner"]!!
-                    val name = call.parameters["name"]!!
-                    val file = call.parameters["file"]!!
-                    val actionCoords =
-                        ActionCoords(
-                            owner = owner,
-                            name = name,
-                            version = "irrelevant",
-                        )
-                    val bindingArtifacts = actionCoords.buildPackageArtifacts(githubToken = getGithubToken())
-                    if (file in bindingArtifacts) {
-                        when (val artifact = bindingArtifacts[file]) {
-                            is String -> call.respondText(artifact)
-                            else -> call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
-                        }
-                    } else {
-                        call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
-                    }
+                route("{owner}/{name}/{file}") {
+                    metadata()
                 }
             }
 
@@ -128,4 +46,98 @@ fun main() {
             }
         }
     }.start(wait = true)
+}
+
+private fun Route.metadata() {
+    get {
+        val owner = call.parameters["owner"]!!
+        val name = call.parameters["name"]!!
+        val file = call.parameters["file"]!!
+        val actionCoords =
+            ActionCoords(
+                owner = owner,
+                name = name,
+                version = "irrelevant",
+            )
+        val bindingArtifacts = actionCoords.buildPackageArtifacts(githubToken = getGithubToken())
+        if (file in bindingArtifacts) {
+            when (val artifact = bindingArtifacts[file]) {
+                is String -> call.respondText(artifact)
+                else -> call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
+            }
+        } else {
+            call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
+        }
+    }
+}
+
+private fun Route.artifact(bindingsCache: Cache<ActionCoords, Result<Map<String, Artifact>>>) {
+    get {
+        val owner = call.parameters["owner"]!!
+        val name = call.parameters["name"]!!
+        val version = call.parameters["version"]!!
+        val actionCoords =
+            ActionCoords(
+                owner = owner,
+                name = name,
+                version = version,
+            )
+        println("➡️ Requesting ${actionCoords.prettyPrint}")
+        val bindingArtifacts =
+            bindingsCache.get(actionCoords) {
+                actionCoords.buildVersionArtifacts()?.let {
+                    Result.success(it)
+                } ?: Result.failure(object : Throwable() {})
+            }.getOrNull()
+
+        if (bindingArtifacts == null) {
+            call.respondText("Not found", status = HttpStatusCode.NotFound)
+            return@get
+        }
+
+        val file = call.parameters["file"]!!
+        if (file in bindingArtifacts) {
+            when (val artifact = bindingArtifacts[file]) {
+                is TextArtifact -> call.respondText(artifact.data)
+                is JarArtifact ->
+                    call.respondBytes(
+                        bytes = artifact.data,
+                        contentType = ContentType.parse("application/java-archive"),
+                    )
+
+                else -> call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
+            }
+        } else {
+            call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
+        }
+    }
+
+    head {
+        val owner = call.parameters["owner"]!!
+        val name = call.parameters["name"]!!
+        val version = call.parameters["version"]!!
+        val file = call.parameters["file"]!!
+        val actionCoords =
+            ActionCoords(
+                owner = owner,
+                name = name,
+                version = version,
+            )
+        val bindingArtifacts =
+            bindingsCache.get(actionCoords) {
+                actionCoords.buildVersionArtifacts()?.let {
+                    Result.success(it)
+                } ?: Result.failure(object : Throwable() {})
+            }.getOrNull()
+
+        if (bindingArtifacts == null) {
+            call.respondText("Not found", status = HttpStatusCode.NotFound)
+            return@head
+        }
+        if (file in bindingArtifacts) {
+            call.respondText("Exists", status = HttpStatusCode.OK)
+        } else {
+            call.respondText(text = "Not found", status = HttpStatusCode.NotFound)
+        }
+    }
 }


### PR DESCRIPTION
Part of #1492.

In the next change, we'll add alternative routes with the same logic, i.e. without the leading `/binding`. Later on, once we migrate all known usages, `/binding` will be removed.