### PR TITLE
feat(server): add routing without '/binding'

### DIFF
--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -77,6 +77,14 @@ workflow(
         }
 
         run(
+            name = "Execute the script using the bindings from the serve - with /binding",
+            command = """
+                mv .github/workflows/test-script-consuming-jit-bindings-old.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings-old.main.kts
+                .github/workflows/test-script-consuming-jit-bindings-old.main.kts
+            """.trimIndent(),
+        )
+
+        run(
             name = "Execute the script using the bindings from the server",
             command = """
                 mv .github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings.main.kts
@@ -85,12 +93,21 @@ workflow(
         )
 
         run(
-            name = "Fetch maven-metadata.xml for top-level action",
+            name = "Fetch maven-metadata.xml for top-level action - with /binding",
             command = "curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml | grep '<version>v4</version>'",
         )
         run(
-            name = "Fetch maven-metadata.xml for nested action",
+            name = "Fetch maven-metadata.xml for nested action - with /binding",
             command = "curl --fail http://localhost:8080/binding/actions/cache__save/maven-metadata.xml | grep '<version>v4</version>'",
+        )
+
+        run(
+            name = "Fetch maven-metadata.xml for top-level action",
+            command = "curl --fail http://localhost:8080/actions/checkout/maven-metadata.xml | grep '<version>v4</version>'",
+        )
+        run(
+            name = "Fetch maven-metadata.xml for nested action",
+            command = "curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep '<version>v4</version>'",
         )
     }
 

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -43,16 +43,27 @@ jobs:
         GHWKT_GITHUB_CONTEXT_JSON: '${{ toJSON(github) }}'
       run: 'GHWKT_RUN_STEP=''end-to-end-test:step-3'' ''.github/workflows/bindings-server.main.kts'''
     - id: 'step-4'
+      name: 'Execute the script using the bindings from the serve - with /binding'
+      run: |-
+        mv .github/workflows/test-script-consuming-jit-bindings-old.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings-old.main.kts
+        .github/workflows/test-script-consuming-jit-bindings-old.main.kts
+    - id: 'step-5'
       name: 'Execute the script using the bindings from the server'
       run: |-
         mv .github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings.main.kts
         .github/workflows/test-script-consuming-jit-bindings.main.kts
-    - id: 'step-5'
-      name: 'Fetch maven-metadata.xml for top-level action'
-      run: 'curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
     - id: 'step-6'
-      name: 'Fetch maven-metadata.xml for nested action'
+      name: 'Fetch maven-metadata.xml for top-level action - with /binding'
+      run: 'curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
+    - id: 'step-7'
+      name: 'Fetch maven-metadata.xml for nested action - with /binding'
       run: 'curl --fail http://localhost:8080/binding/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
+    - id: 'step-8'
+      name: 'Fetch maven-metadata.xml for top-level action'
+      run: 'curl --fail http://localhost:8080/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
+    - id: 'step-9'
+      name: 'Fetch maven-metadata.xml for nested action'
+      run: 'curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
   deploy:
     name: 'Deploy to DockerHub'
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/test-script-consuming-jit-bindings-old.main.do-not-compile.kts
+++ b/.github/workflows/test-script-consuming-jit-bindings-old.main.do-not-compile.kts
@@ -2,7 +2,7 @@
 @file:Repository("https://repo1.maven.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.13.0")
 
-@file:Repository("http://localhost:8080")
+@file:Repository("http://localhost:8080/binding/")
 
 // Regular, top-level action.
 @file:DependsOn("actions:checkout:v4")

--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
@@ -31,6 +31,8 @@ fun main() {
 
     embeddedServer(Netty, port = 8080) {
         routing {
+            // TODO: remove this route once known clients are migrated
+            // See https://github.com/typesafegithub/github-workflows-kt/issues/1492
             route("/binding") {
                 route("{owner}/{name}/{version}/{file}") {
                     artifact(bindingsCache)
@@ -39,6 +41,14 @@ fun main() {
                 route("{owner}/{name}/{file}") {
                     metadata()
                 }
+            }
+
+            route("{owner}/{name}/{version}/{file}") {
+                artifact(bindingsCache)
+            }
+
+            route("{owner}/{name}/{file}") {
+                metadata()
             }
 
             get("/status") {


### PR DESCRIPTION
Part of #1492.

It adds an alternative routing, without the `/binding` part, thanks to which the user-facing URL will be shorter and nicer.