### PR TITLE
chore: use new URL for Maven Central

### DIFF
--- a/.github/workflows/actions-versions.main.kts
+++ b/.github/workflows/actions-versions.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/check-if-action-bindings-up-to-date.main.kts
+++ b/.github/workflows/check-if-action-bindings-up-to-date.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/create-action-update-prs.main.kts
+++ b/.github/workflows/create-action-update-prs.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/gradle-wrapper-validation.main.kts
+++ b/.github/workflows/gradle-wrapper-validation.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/release-common.main.kts
+++ b/.github/workflows/release-common.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/release-docs.main.kts
+++ b/.github/workflows/release-docs.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/setup-java.main.kts
+++ b/.github/workflows/setup-java.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/setup-python.main.kts
+++ b/.github/workflows/setup-python.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:2.1.0")
 
 @file:Repository("https://bindings.krzeminski.it")

--- a/.github/workflows/test-script-consuming-jit-bindings-old.main.do-not-compile.kts
+++ b/.github/workflows/test-script-consuming-jit-bindings-old.main.do-not-compile.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.13.0")
 
 @file:Repository("http://localhost:8080/binding/")

--- a/.github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts
+++ b/.github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.13.0")
 
 @file:Repository("http://localhost:8080")

--- a/buildSrc/src/main/kotlin/buildsrc/tasks/AwaitMavenCentralDeployTask.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/tasks/AwaitMavenCentralDeployTask.kt
@@ -28,7 +28,7 @@ abstract class AwaitMavenCentralDeployTask : DefaultTask() {
 
     @TaskAction
     fun awaitDeployment(): Unit = runBlocking {
-        val queriedUrl = "https://repo1.maven.org/maven2/" +
+        val queriedUrl = "https://repo.maven.apache.org/maven2/" +
             groupId.get().replace(".", "/") +
             "/${artifactId.get()}" +
             "/${version.get()}" +

--- a/docs/user-guide/migrating-to-Maven-based-bindings.md
+++ b/docs/user-guide/migrating-to-Maven-based-bindings.md
@@ -53,7 +53,7 @@ demand, and is then shipped as a separate Maven artifact from a custom Maven-com
 The following changes are required in our example workflow:
    ```diff
      #!/usr/bin/env kotlin
-   + @file:Repository("https://repo1.maven.org/maven2/")
+   + @file:Repository("https://repo.maven.apache.org/maven2/")
      @file:DependsOn("io.github.typesafegithub:github-workflows-kt:<newest-version>")
    + @file:Repository("https://bindings.krzeminski.it")
    + @file:DependsOn("actions:checkout:v4")


### PR DESCRIPTION
It's the new one, used e.g. in Gradle in `mavenCentral()` function.