### PR TITLE
fix(server): add dependency on library in action binding JAR

### DIFF
--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -93,6 +93,14 @@ workflow(
         )
 
         run(
+            name = "Execute the script using bindings but without dependency on library",
+            command = """
+                mv .github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts .github/workflows/test-served-bindings-depend-on-library.main.kts
+                .github/workflows/test-served-bindings-depend-on-library.main.kts
+            """.trimIndent(),
+        )
+
+        run(
             name = "Fetch maven-metadata.xml for top-level action - with /binding",
             command = "curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml | grep '<version>v4</version>'",
         )

--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -37,6 +37,9 @@ workflow(
         PullRequest(),
     ),
     sourceFile = __FILE__,
+    env = mapOf(
+        "COMPILED_SCRIPTS_CACHE_DIR_ENV_VAR" to "",
+    )
 ) {
     val endToEndTest = job(
         id = "end-to-end-test",

--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -37,9 +37,6 @@ workflow(
         PullRequest(),
     ),
     sourceFile = __FILE__,
-    env = mapOf(
-        "COMPILED_SCRIPTS_CACHE_DIR_ENV_VAR" to "",
-    )
 ) {
     val endToEndTest = job(
         id = "end-to-end-test",
@@ -93,6 +90,11 @@ workflow(
                 mv .github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings.main.kts
                 .github/workflows/test-script-consuming-jit-bindings.main.kts
             """.trimIndent(),
+        )
+
+        run(
+            name = "Clean Maven Local to fetch required POMs again",
+            command = "rm -rf ~/.m2/repository/"
         )
 
         run(

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -53,15 +53,20 @@ jobs:
         mv .github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings.main.kts
         .github/workflows/test-script-consuming-jit-bindings.main.kts
     - id: 'step-6'
+      name: 'Execute the script using bindings but without dependency on library'
+      run: |-
+        mv .github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts .github/workflows/test-served-bindings-depend-on-library.main.kts
+        .github/workflows/test-served-bindings-depend-on-library.main.kts
+    - id: 'step-7'
       name: 'Fetch maven-metadata.xml for top-level action - with /binding'
       run: 'curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-7'
+    - id: 'step-8'
       name: 'Fetch maven-metadata.xml for nested action - with /binding'
       run: 'curl --fail http://localhost:8080/binding/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-8'
+    - id: 'step-9'
       name: 'Fetch maven-metadata.xml for top-level action'
       run: 'curl --fail http://localhost:8080/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-9'
+    - id: 'step-10'
       name: 'Fetch maven-metadata.xml for nested action'
       run: 'curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
   deploy:

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -8,6 +8,8 @@ on:
     branches:
     - 'main'
   pull_request: {}
+env:
+  COMPILED_SCRIPTS_CACHE_DIR_ENV_VAR: ''
 jobs:
   check_yaml_consistency:
     name: 'Check YAML consistency'

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -8,8 +8,6 @@ on:
     branches:
     - 'main'
   pull_request: {}
-env:
-  COMPILED_SCRIPTS_CACHE_DIR_ENV_VAR: ''
 jobs:
   check_yaml_consistency:
     name: 'Check YAML consistency'
@@ -55,20 +53,23 @@ jobs:
         mv .github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings.main.kts
         .github/workflows/test-script-consuming-jit-bindings.main.kts
     - id: 'step-6'
+      name: 'Clean Maven Local to fetch required POMs again'
+      run: 'rm -rf ~/.m2/repository/'
+    - id: 'step-7'
       name: 'Execute the script using bindings but without dependency on library'
       run: |-
         mv .github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts .github/workflows/test-served-bindings-depend-on-library.main.kts
         .github/workflows/test-served-bindings-depend-on-library.main.kts
-    - id: 'step-7'
+    - id: 'step-8'
       name: 'Fetch maven-metadata.xml for top-level action - with /binding'
       run: 'curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-8'
+    - id: 'step-9'
       name: 'Fetch maven-metadata.xml for nested action - with /binding'
       run: 'curl --fail http://localhost:8080/binding/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-9'
+    - id: 'step-10'
       name: 'Fetch maven-metadata.xml for top-level action'
       run: 'curl --fail http://localhost:8080/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-10'
+    - id: 'step-11'
       name: 'Fetch maven-metadata.xml for nested action'
       run: 'curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
   deploy:

--- a/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
+++ b/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
@@ -1,0 +1,8 @@
+#!/usr/bin/env kotlin
+@file:Repository("https://repo.maven.apache.org/maven2/")
+@file:Repository("http://localhost:8080")
+@file:DependsOn("actions:checkout:v4")
+
+import io.github.typesafegithub.workflows.actions.actions.Checkout
+
+Checkout()

--- a/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
+++ b/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
@@ -3,7 +3,6 @@
 @file:Repository("http://localhost:8080")
 @file:DependsOn("actions:checkout:v4")
 
-println("before import")
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 println("after import")
 

--- a/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
+++ b/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
@@ -3,6 +3,7 @@
 @file:Repository("http://localhost:8080")
 @file:DependsOn("actions:checkout:v4")
 
-import io.github.typesafegithub.workflows.actions.actions.Checkout
+println(System.getProperty("java.class.path"))
+// import io.github.typesafegithub.workflows.actions.actions.Checkout
 
-Checkout()
+// Checkout()

--- a/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
+++ b/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
@@ -3,7 +3,10 @@
 @file:Repository("http://localhost:8080")
 @file:DependsOn("actions:checkout:v4")
 
-println(System.getProperty("java.class.path"))
-// import io.github.typesafegithub.workflows.actions.actions.Checkout
+println("before import")
+import io.github.typesafegithub.workflows.actions.actions.Checkout
+println("after import")
 
-// Checkout()
+println("before instantiating Checkout")
+Checkout()
+println("after instantiating Checkout")

--- a/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
+++ b/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
@@ -4,8 +4,5 @@
 @file:DependsOn("actions:checkout:v4")
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout
-println("after import")
 
-println("before instantiating Checkout")
 Checkout()
-println("after instantiating Checkout")

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -4,7 +4,7 @@ This file describes various maintenance tasks, relevant for project maintainers 
 
 It currently happens monthly, around the beginning of each month. We don't need to stick to this cadence strictly, the goal is to publish small frequent updates.
 
-1. Remove `-SNAPSHOT` for version starting from [/github-workflows-kt/build.gradle.kts](https://github.com/typesafegithub/github-workflows-kt/blob/main/github-workflows-kt/build.gradle.kts). By building the whole project with `./gradlew build`, you will learn what other places need to be adjusted. Once done, create a commit using this pattern for commit message: `chore: prepare for releasing version <version>`.
+1. Remove `-SNAPSHOT` for version starting from [/github-workflows-kt/build.gradle.kts](https://github.com/typesafegithub/github-workflows-kt/blob/main/github-workflows-kt/build.gradle.kts). By building the whole project with `./gradlew build`, you will learn what other places need to be adjusted. There's one place that needs extra care: in PomBuilding.kt, there's `LATEST_RELASED_LIBRARY_VERSION` - set it to the version you're going to deploy in a minute. Once done, create a commit using this pattern for commit message: `chore: prepare for releasing version <version>`.
 1. Once CI is green for the newly merged commits, create and push an annotated tag:
    ```
    COMMIT_TITLE=`git log -1 --pretty=%B`

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PomBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PomBuilding.kt
@@ -1,5 +1,7 @@
 package io.github.typesafegithub.workflows.mavenbinding
 
+internal const val LATEST_RELASED_LIBRARY_VERSION = "2.1.0"
+
 internal fun buildPomFile(
     owner: String,
     name: String,
@@ -24,7 +26,7 @@ internal fun buildPomFile(
         <dependency>
             <groupId>io.github.typesafegithub</groupId>
             <artifactId>github-workflows-kt</artifactId>
-            <version>2.1.0</version>
+            <version>$LATEST_RELASED_LIBRARY_VERSION</version>
             <scope>compile</scope>
         </dependency>
       </dependencies>

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PomBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PomBuilding.kt
@@ -20,6 +20,13 @@ internal fun buildPomFile(
         <developerConnection>scm:git:ssh://github.com:$owner/$name.git</developerConnection>
         <url>https://github.com/$owner/$name.git</url>
       </scm>
-      <dependencies></dependencies>
+      <dependencies>
+        <dependency>
+            <groupId>io.github.typesafegithub</groupId>
+            <artifactId>github-workflows-kt</artifactId>
+            <version>2.1.0</version>
+            <scope>compile</scope>
+        </dependency>
+      </dependencies>
     </project>
     """.trimIndent()


### PR DESCRIPTION
Thanks to this, one doesn't have to explicitly depend on the library if a given script uses only the binding. It saves one `@file:Repository` line from the user's script.