### PR TITLE
feat(server): define Maven Central repository in action bindings' POMs

### DIFF
--- a/.github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts
+++ b/.github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts
@@ -1,5 +1,4 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.13.0")
 
 @file:Repository("http://localhost:8080")

--- a/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
+++ b/.github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts
@@ -1,5 +1,4 @@
 #!/usr/bin/env kotlin
-@file:Repository("https://repo.maven.apache.org/maven2/")
 @file:Repository("http://localhost:8080")
 @file:DependsOn("actions:checkout:v4")
 

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PomBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PomBuilding.kt
@@ -22,6 +22,14 @@ internal fun buildPomFile(
         <developerConnection>scm:git:ssh://github.com:$owner/$name.git</developerConnection>
         <url>https://github.com/$owner/$name.git</url>
       </scm>
+      <repositories>
+        <repository>
+          <name>Maven Central</name>
+          <id>maven-central</id>
+          <url>https://repo.maven.apache.org/maven2/</url>
+          <layout>default</layout>
+        </repository>
+      </repositories>
       <dependencies>
         <dependency>
             <groupId>io.github.typesafegithub</groupId>


### PR DESCRIPTION
Thanks to this, one doesn't have to add an explicit dependency on Maven Central if using bindings provided by the server, and if no other dependency is needed from Maven Central.