### PR TITLE
chore(ci): deploy only on Sunday or on demand

### DIFF
--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -11,8 +11,7 @@ import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
 import io.github.typesafegithub.workflows.annotations.ExperimentalKotlinLogicStep
 import io.github.typesafegithub.workflows.domain.Environment
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
-import io.github.typesafegithub.workflows.domain.triggers.PullRequest
-import io.github.typesafegithub.workflows.domain.triggers.Push
+import io.github.typesafegithub.workflows.domain.triggers.*
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
@@ -35,6 +34,8 @@ workflow(
     on = listOf(
         Push(branches = listOf("main")),
         PullRequest(),
+        Schedule(triggers = listOf(Cron(minute = "0", hour = "0", dayWeek = "SUN"))),
+        WorkflowDispatch(),
     ),
     sourceFile = __FILE__,
 ) {
@@ -128,7 +129,7 @@ workflow(
         id = "deploy",
         name = "Deploy to DockerHub",
         runsOn = UbuntuLatest,
-        `if` = expr { "${github.event_name} == 'push'" },
+        `if` = expr { "${github.event_name} == 'workflow_dispatch' || ${github.event_name} == 'schedule'" },
         needs = listOf(endToEndTest),
         env = mapOf(
             "DOCKERHUB_USERNAME" to expr { DOCKERHUB_USERNAME },

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -8,6 +8,9 @@ on:
     branches:
     - 'main'
   pull_request: {}
+  schedule:
+  - cron: '0 0 * * SUN'
+  workflow_dispatch: {}
 jobs:
   check_yaml_consistency:
     name: 'Check YAML consistency'
@@ -81,7 +84,7 @@ jobs:
     env:
       DOCKERHUB_USERNAME: '${{ secrets.DOCKERHUB_USERNAME }}'
       DOCKERHUB_PASSWORD: '${{ secrets.DOCKERHUB_PASSWORD }}'
-    if: '${{ github.event_name == ''push'' }}'
+    if: '${{ github.event_name == ''workflow_dispatch'' || github.event_name == ''schedule'' }}'
     environment:
       name: 'DockerHub'
     steps:


### PR DESCRIPTION
It's because whenever a deployment happens, there's a short downtime. The problem is not yet solved, so as a workaround, let's deploy in a controlled manner (and not e.g. at every Renovate update), at a time where little traffic should flow (Sunday, midnight UTC).