### PR TITLE
fix(abg): allow using percent sign in action API description

### DIFF
--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithFancyCharsInDocsV3.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithFancyCharsInDocsV3.kt
@@ -1,0 +1,74 @@
+// This file was generated using action-binding-generator. Don't change it by hand, otherwise your
+// changes will be overwritten with the next binding code regeneration.
+// See https://github.com/typesafegithub/github-workflows-kt for more info.
+@file:Suppress(
+    "DataClassPrivateConstructor",
+    "UNUSED_PARAMETER",
+)
+
+package io.github.typesafegithub.workflows.actions.johnsmith
+
+import io.github.typesafegithub.workflows.domain.actions.Action
+import io.github.typesafegithub.workflows.domain.actions.RegularAction
+import java.util.LinkedHashMap
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.collections.toList
+import kotlin.collections.toTypedArray
+
+/**
+ * Action: Do something cool
+ *
+ * This is a test description that should be put in the KDoc comment for a class
+ *
+ * [Action on GitHub](https://github.com/john-smith/action-with-fancy-chars-in-docs)
+ *
+ * @param nestedKotlinComments This is a /&#42; test &#42;/
+ * @param percent For example "100%"
+ * @param _customInputs Type-unsafe map where you can put any inputs that are not yet supported by
+ * the binding
+ * @param _customVersion Allows overriding action's version, for example to use a specific minor
+ * version, or a newer version that the binding doesn't yet know about
+ */
+public data class ActionWithFancyCharsInDocsV3 private constructor(
+    /**
+     * This is a /&#42; test &#42;/
+     */
+    public val nestedKotlinComments: String? = null,
+    /**
+     * For example "100%"
+     */
+    public val percent: String? = null,
+    /**
+     * Type-unsafe map where you can put any inputs that are not yet supported by the binding
+     */
+    public val _customInputs: Map<String, String> = mapOf(),
+    /**
+     * Allows overriding action's version, for example to use a specific minor version, or a newer
+     * version that the binding doesn't yet know about
+     */
+    public val _customVersion: String? = null,
+) : RegularAction<Action.Outputs>("john-smith", "action-with-fancy-chars-in-docs", _customVersion ?:
+        "v3") {
+    public constructor(
+        vararg pleaseUseNamedArguments: Unit,
+        nestedKotlinComments: String? = null,
+        percent: String? = null,
+        _customInputs: Map<String, String> = mapOf(),
+        _customVersion: String? = null,
+    ) : this(nestedKotlinComments=nestedKotlinComments, percent=percent,
+            _customInputs=_customInputs, _customVersion=_customVersion)
+
+    @Suppress("SpreadOperator")
+    override fun toYamlArguments(): LinkedHashMap<String, String> = linkedMapOf(
+        *listOfNotNull(
+            nestedKotlinComments?.let { "nested-kotlin-comments" to it },
+            percent?.let { "percent" to it },
+            *_customInputs.toList().toTypedArray(),
+        ).toTypedArray()
+    )
+
+    override fun buildOutputObject(stepId: String): Action.Outputs = Outputs(stepId)
+}

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -387,4 +387,32 @@ class GenerationTest :
             binding shouldNotBe null
             binding?.shouldMatchFile("ActionForGeneratedJar.kt")
         }
+
+        test("action with input descriptions with fancy characters") {
+            // given
+            val actionManifest =
+                Metadata(
+                    name = "Do something cool",
+                    description = "This is a test description that should be put in the KDoc comment for a class",
+                    inputs =
+                        mapOf(
+                            "nested-kotlin-comments" to
+                                Input(
+                                    description = "This is a /* test */",
+                                ),
+                            "percent" to
+                                Input(
+                                    description = "For example \"100%\"",
+                                ),
+                        ),
+                )
+            val coords = ActionCoords("john-smith", "action-with-fancy-chars-in-docs", "v3")
+
+            // when
+            val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
+
+            // then
+            binding shouldNotBe null
+            binding?.shouldMatchFile("ActionWithFancyCharsInDocsV3.kt")
+        }
     })


### PR DESCRIPTION
Fixes #1562.

Percent sign is used by KotlinPoet for placeholders, see https://square.github.io/kotlinpoet/1.x/kotlinpoet/kotlinpoet/com.squareup.kotlinpoet/-code-block/index.html