### PR TITLE
fix(server): evict cache entry after 1 hour of write, not access

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
@@ -29,7 +29,7 @@ fun main() {
     val bindingsCache =
         Cache
             .Builder<ActionCoords, Result<Map<String, Artifact>>>()
-            .expireAfterAccess(1.hours)
+            .expireAfterWrite(1.hours)
             .build()
     val openTelemetry = buildOpenTelemetryConfig(serviceName = "github-actions-bindings")
 


### PR DESCRIPTION
Because of this bug, some entry could live forever, until the next server restart, because each access would effecively prolong their life in the cache by 1 hour. It's undesirable - we want to treat the cached bindings as if they were valid since their generation for 1 hour.