### PR TITLE
chore(abg): remove MetadataRevision.FromLockfile

### DIFF
--- a/action-binding-generator/api/action-binding-generator.api
+++ b/action-binding-generator/api/action-binding-generator.api
@@ -37,13 +37,6 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/dom
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/github/typesafegithub/workflows/actionbindinggenerator/domain/FromLockfile : io/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/FromLockfile;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract interface class io/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision {
 }
 

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision.kt
@@ -4,8 +4,6 @@ public sealed interface MetadataRevision
 
 public data object NewestForVersion : MetadataRevision
 
-public data object FromLockfile : MetadataRevision
-
 public data class CommitHash(
     val value: String,
 ) : MetadataRevision

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/metadata/MetadataReading.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/metadata/MetadataReading.kt
@@ -2,7 +2,6 @@ package io.github.typesafegithub.workflows.actionbindinggenerator.metadata
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.CommitHash
-import io.github.typesafegithub.workflows.actionbindinggenerator.domain.FromLockfile
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.MetadataRevision
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestForVersion
 import io.github.typesafegithub.workflows.actionbindinggenerator.utils.myYaml
@@ -10,7 +9,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import java.io.IOException
 import java.net.URI
-import java.nio.file.Path
 
 /**
  * [Metadata syntax for GitHub Actions](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions).
@@ -47,8 +45,6 @@ private fun ActionCoords.actionYamlUrl(gitRef: String) =
         '/',
     )}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yaml"
 
-internal val ActionCoords.releasesUrl: String get() = "$gitHubUrl/releases"
-
 internal val ActionCoords.gitHubUrl: String get() = "https://github.com/$owner/$name"
 
 public fun ActionCoords.fetchMetadata(
@@ -59,7 +55,6 @@ public fun ActionCoords.fetchMetadata(
         when (metadataRevision) {
             is CommitHash -> metadataRevision.value
             NewestForVersion -> this.version
-            FromLockfile -> this.getCommitHashFromFileSystem()
         }
     val list = listOf(actionYmlUrl(gitRef), actionYamlUrl(gitRef))
 
@@ -73,12 +68,5 @@ public fun ActionCoords.fetchMetadata(
             }
         }?.let { myYaml.decodeFromString(it) }
 }
-
-private fun ActionCoords.getCommitHashFromFileSystem(): String =
-    Path
-        .of("actions", owner, name.substringBefore('/'), version, "commit-hash.txt")
-        .toFile()
-        .readText()
-        .trim()
 
 internal fun fetchUri(uri: URI): String = uri.toURL().readText()

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
@@ -3,7 +3,6 @@ package io.github.typesafegithub.workflows.actionbindinggenerator.typing
 import com.charleskorn.kaml.Yaml
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.CommitHash
-import io.github.typesafegithub.workflows.actionbindinggenerator.domain.FromLockfile
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.MetadataRevision
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestForVersion
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
@@ -18,7 +17,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import java.io.IOException
 import java.net.URI
-import java.nio.file.Path
 
 internal fun ActionCoords.provideTypes(
     metadataRevision: MetadataRevision,
@@ -52,8 +50,7 @@ private fun ActionCoords.fetchTypingMetadata(
         when (metadataRevision) {
             is CommitHash -> metadataRevision.value
             NewestForVersion -> this.version
-            FromLockfile -> getCommitHash(this)
-        } ?: return null
+        }
     val list = listOf(actionTypesYmlUrl(gitRef), actionTypesYamlUrl(gitRef))
     val typesMetadataYaml =
         list.firstNotNullOfOrNull { url ->
@@ -110,14 +107,6 @@ private fun fetchTypingsFromUrl(
         } ?: return null
     return myYaml.decodeFromStringOrDefaultIfEmpty(typesMetadataYml, ActionTypes())
 }
-
-internal fun getCommitHash(actionCoords: ActionCoords): String? =
-    Path
-        .of("actions", actionCoords.owner, actionCoords.name, actionCoords.version, "commit-hash.txt")
-        .toFile()
-        .let {
-            if (it.exists()) it.readText().trim() else null
-        }
 
 internal fun ActionTypes.toTypesMap(): Map<String, Typing> =
     inputs.mapValues { (key, value) ->

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -1,7 +1,7 @@
 package io.github.typesafegithub.workflows.actionbindinggenerator.generation
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
-import io.github.typesafegithub.workflows.actionbindinggenerator.domain.FromLockfile
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestForVersion
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource.ACTION
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.Input
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.Metadata
@@ -140,7 +140,7 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "simple-action-with-required-string-inputs", "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
+            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
             binding shouldNotBe null
@@ -186,7 +186,7 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "action-with-some-optional-inputs", "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
+            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
             binding shouldNotBe null
@@ -200,7 +200,7 @@ class GenerationTest :
             // when
             val binding =
                 coords.generateBinding(
-                    metadataRevision = FromLockfile,
+                    metadataRevision = NewestForVersion,
                     metadata = actionManifestWithAllTypesOfInputsAndSomeOutput,
                     inputTypings =
                         Pair(
@@ -238,7 +238,7 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "action-with-outputs", "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
+            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
             binding shouldNotBe null
@@ -258,7 +258,7 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "action-with-no-inputs", "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
+            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
             binding shouldNotBe null
@@ -278,7 +278,7 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "deprecated-action", "v2", deprecatedByVersion = "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
+            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
             binding?.shouldMatchFile("DeprecatedActionV2.kt")
@@ -311,7 +311,7 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "action-with-deprecated-input-and-name-clash", "v2")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
+            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
             binding shouldNotBe null
@@ -348,7 +348,7 @@ class GenerationTest :
             // when
             val binding =
                 coords.generateBinding(
-                    metadataRevision = FromLockfile,
+                    metadataRevision = NewestForVersion,
                     metadata = actionManifest,
                     inputTypings =
                         Pair(
@@ -373,7 +373,7 @@ class GenerationTest :
             // when
             val binding =
                 coords.generateBinding(
-                    metadataRevision = FromLockfile,
+                    metadataRevision = NewestForVersion,
                     metadata = actionManifestWithAllTypesOfInputsAndSomeOutput,
                     clientType = ClientType.VERSIONED_JAR,
                     inputTypings =
@@ -409,7 +409,7 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "action-with-fancy-chars-in-docs", "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = FromLockfile, metadata = actionManifest)
+            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
             binding shouldNotBe null


### PR DESCRIPTION
It's no longer used since we've removed the lockfiles from this repo.