### PR TITLE
fix(ci): remove non-existing input from action in end-to-end tests

### DIFF
--- a/.github/workflows/end-to-end-tests.main.kts
+++ b/.github/workflows/end-to-end-tests.main.kts
@@ -36,7 +36,7 @@ fun JobBuilder<*>.publishToMavenLocal() {
             distribution = SetupJava.Distribution.Zulu,
         ),
     )
-    uses(action = ActionsSetupGradle(generateJobSummary = false))
+    uses(action = ActionsSetupGradle())
     run(
         name = "Publish to Maven local",
         command = "./gradlew publishToMavenLocal",

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -26,8 +26,6 @@ jobs:
         distribution: 'zulu'
     - id: 'step-2'
       uses: 'gradle/actions/setup-gradle@v4'
-      with:
-        generate-job-summary: 'false'
     - id: 'step-3'
       name: 'Publish to Maven local'
       run: './gradlew publishToMavenLocal'
@@ -126,8 +124,6 @@ jobs:
         distribution: 'zulu'
     - id: 'step-16'
       uses: 'gradle/actions/setup-gradle@v4'
-      with:
-        generate-job-summary: 'false'
     - id: 'step-17'
       name: 'Publish to Maven local'
       run: './gradlew publishToMavenLocal'


### PR DESCRIPTION
The action doesn't have `generate-job-summary` input anymore.
I prematurely force-merged this PR: https://github.com/typesafegithub/github-workflows-kt/pull/1577 - it would be caught there!