### PR TITLE
refactor: prepare for generating more than one binding class

### DIFF
--- a/action-binding-generator/api/action-binding-generator.api
+++ b/action-binding-generator/api/action-binding-generator.api
@@ -72,8 +72,8 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/gen
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationKt {
-	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;)Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ActionBinding;
-	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/generation/ActionBinding;
+	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;)Ljava/util/List;
+	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;ILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/metadata/Input {

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
@@ -57,8 +57,8 @@ public fun ActionCoords.generateBinding(
     metadataRevision: MetadataRevision,
     metadata: Metadata? = null,
     inputTypings: Pair<Map<String, Typing>, TypingActualSource?>? = null,
-): ActionBinding? {
-    val metadataResolved = metadata ?: this.fetchMetadata(metadataRevision) ?: return null
+): List<ActionBinding> {
+    val metadataResolved = metadata ?: this.fetchMetadata(metadataRevision) ?: return emptyList()
     val metadataProcessed = metadataResolved.removeDeprecatedInputsIfNameClash()
 
     val inputTypingsResolved = inputTypings ?: this.provideTypes(metadataRevision)
@@ -67,12 +67,14 @@ public fun ActionCoords.generateBinding(
     val actionBindingSourceCode =
         generateActionBindingSourceCode(metadataProcessed, this, inputTypingsResolved.first, className)
     val packageName = owner.toKotlinPackageName()
-    return ActionBinding(
-        kotlinCode = actionBindingSourceCode,
-        filePath = "kotlin/io/github/typesafegithub/workflows/actions/$packageName/$className.kt",
-        className = className,
-        packageName = packageName,
-        typingActualSource = inputTypingsResolved.second,
+    return listOf(
+        ActionBinding(
+            kotlinCode = actionBindingSourceCode,
+            filePath = "kotlin/io/github/typesafegithub/workflows/actions/$packageName/$className.kt",
+            className = className,
+            packageName = packageName,
+            typingActualSource = inputTypingsResolved.second,
+        ),
     )
 }
 

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -15,7 +15,7 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.typing.IntegerW
 import io.github.typesafegithub.workflows.actionbindinggenerator.typing.ListOfTypings
 import io.github.typesafegithub.workflows.actionbindinggenerator.typing.StringTyping
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.collections.shouldHaveSize
 
 class GenerationTest :
     FunSpec({
@@ -143,8 +143,8 @@ class GenerationTest :
             val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
-            binding shouldNotBe null
-            binding?.shouldMatchFile("SimpleActionWithRequiredStringInputs.kt")
+            binding shouldHaveSize 1
+            binding.first().shouldMatchFile("SimpleActionWithRequiredStringInputs.kt")
         }
 
         test("action with various combinations of input parameters describing being required or optional") {
@@ -189,8 +189,8 @@ class GenerationTest :
             val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
-            binding shouldNotBe null
-            binding?.shouldMatchFile("ActionWithSomeOptionalInputs.kt")
+            binding shouldHaveSize 1
+            binding.first().shouldMatchFile("ActionWithSomeOptionalInputs.kt")
         }
 
         test("action with all types of inputs") {
@@ -210,8 +210,8 @@ class GenerationTest :
                 )
 
             // then
-            binding shouldNotBe null
-            binding?.shouldMatchFile("ActionWithAllTypesOfInputs.kt")
+            binding shouldHaveSize 1
+            binding.first().shouldMatchFile("ActionWithAllTypesOfInputs.kt")
         }
 
         test("action with outputs") {
@@ -241,8 +241,8 @@ class GenerationTest :
             val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
-            binding shouldNotBe null
-            binding?.shouldMatchFile("ActionWithOutputs.kt")
+            binding shouldHaveSize 1
+            binding.first().shouldMatchFile("ActionWithOutputs.kt")
         }
 
         test("action with no inputs") {
@@ -261,8 +261,8 @@ class GenerationTest :
             val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
-            binding shouldNotBe null
-            binding?.shouldMatchFile("ActionWithNoInputs.kt")
+            binding shouldHaveSize 1
+            binding.first().shouldMatchFile("ActionWithNoInputs.kt")
         }
 
         test("action with deprecated input resolving to the same Kotlin field name") {
@@ -295,8 +295,8 @@ class GenerationTest :
             val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
-            binding shouldNotBe null
-            binding?.shouldMatchFile("ActionWithDeprecatedInputAndNameClash.kt")
+            binding shouldHaveSize 1
+            binding.first().shouldMatchFile("ActionWithDeprecatedInputAndNameClash.kt")
         }
 
         test("action with inputs sharing type") {
@@ -343,8 +343,8 @@ class GenerationTest :
                 )
 
             // then
-            binding shouldNotBe null
-            binding?.shouldMatchFile("ActionWithInputsSharingType.kt")
+            binding shouldHaveSize 1
+            binding.first().shouldMatchFile("ActionWithInputsSharingType.kt")
         }
 
         test("action with input descriptions with fancy characters") {
@@ -371,7 +371,7 @@ class GenerationTest :
             val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
 
             // then
-            binding shouldNotBe null
-            binding?.shouldMatchFile("ActionWithFancyCharsInDocs.kt")
+            binding shouldHaveSize 1
+            binding.first().shouldMatchFile("ActionWithFancyCharsInDocs.kt")
         }
     })


### PR DESCRIPTION
Part of #1585.

Thanks to this, we'll be able to return e.g. `Checkout` and `Checkout_Untyped` classes in a single JAR.