### PR TITLE
test(abg): specify typing in generation test

### DIFF
--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -14,6 +14,7 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.typing.IntegerT
 import io.github.typesafegithub.workflows.actionbindinggenerator.typing.IntegerWithSpecialValueTyping
 import io.github.typesafegithub.workflows.actionbindinggenerator.typing.ListOfTypings
 import io.github.typesafegithub.workflows.actionbindinggenerator.typing.StringTyping
+import io.github.typesafegithub.workflows.actionbindinggenerator.typing.Typing
 import io.kotest.core.spec.style.FunSpec
 
 class GenerationTest :
@@ -139,7 +140,12 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "simple-action-with-required-string-inputs", "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
+            val binding =
+                coords.generateBinding(
+                    metadataRevision = NewestForVersion,
+                    metadata = actionManifest,
+                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                )
 
             // then
             binding.shouldContainAndMatchFile("SimpleActionWithRequiredStringInputs.kt")
@@ -184,7 +190,12 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "action-with-some-optional-inputs", "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
+            val binding =
+                coords.generateBinding(
+                    metadataRevision = NewestForVersion,
+                    metadata = actionManifest,
+                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                )
 
             // then
             binding.shouldContainAndMatchFile("ActionWithSomeOptionalInputs.kt")
@@ -234,7 +245,12 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "action-with-outputs", "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
+            val binding =
+                coords.generateBinding(
+                    metadataRevision = NewestForVersion,
+                    metadata = actionManifest,
+                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                )
 
             // then
             binding.shouldContainAndMatchFile("ActionWithOutputs.kt")
@@ -253,7 +269,12 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "action-with-no-inputs", "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
+            val binding =
+                coords.generateBinding(
+                    metadataRevision = NewestForVersion,
+                    metadata = actionManifest,
+                    inputTypings = Pair(emptyMap(), ACTION),
+                )
 
             // then
             binding.shouldContainAndMatchFile("ActionWithNoInputs.kt")
@@ -286,7 +307,12 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "action-with-deprecated-input-and-name-clash", "v2")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
+            val binding =
+                coords.generateBinding(
+                    metadataRevision = NewestForVersion,
+                    metadata = actionManifest,
+                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                )
 
             // then
             binding.shouldContainAndMatchFile("ActionWithDeprecatedInputAndNameClash.kt")
@@ -360,9 +386,16 @@ class GenerationTest :
             val coords = ActionCoords("john-smith", "action-with-fancy-chars-in-docs", "v3")
 
             // when
-            val binding = coords.generateBinding(metadataRevision = NewestForVersion, metadata = actionManifest)
+            val binding =
+                coords.generateBinding(
+                    metadataRevision = NewestForVersion,
+                    metadata = actionManifest,
+                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                )
 
             // then
             binding.shouldContainAndMatchFile("ActionWithFancyCharsInDocs.kt")
         }
     })
+
+private fun Metadata.allInputsAsStrings(): Map<String, Typing> = this.inputs.mapValues { StringTyping }


### PR DESCRIPTION
Part of #1585.

It's needed because without this change, the generator infers there are no typings for these test actions (the actions actually don't exist), and in the new world it would only produce the `_Untyped` binding for them. These tests actually check the path where the typings are provided. For simplicity, we use `String` everywhere because there's already a test that checks generation for other typings.