### PR TITLE
test: clean Maven Local before compiling scripts in server tests

### DIFF
--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -10,8 +10,10 @@ import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
 import io.github.typesafegithub.workflows.annotations.ExperimentalKotlinLogicStep
 import io.github.typesafegithub.workflows.domain.Environment
+import io.github.typesafegithub.workflows.domain.JobOutputs
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
 import io.github.typesafegithub.workflows.domain.triggers.*
+import io.github.typesafegithub.workflows.dsl.JobBuilder
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
@@ -77,6 +79,8 @@ workflow(
             }
         }
 
+        cleanMavenLocal()
+
         run(
             name = "Execute the script using the bindings from the serve - with /binding",
             command = """
@@ -84,6 +88,8 @@ workflow(
                 .github/workflows/test-script-consuming-jit-bindings-old.main.kts
             """.trimIndent(),
         )
+
+        cleanMavenLocal()
 
         run(
             name = "Execute the script using the bindings from the server",
@@ -93,10 +99,7 @@ workflow(
             """.trimIndent(),
         )
 
-        run(
-            name = "Clean Maven Local to fetch required POMs again",
-            command = "rm -rf ~/.m2/repository/"
-        )
+        cleanMavenLocal()
 
         run(
             name = "Execute the script using bindings but without dependency on library",
@@ -148,4 +151,11 @@ workflow(
             command = "curl -X POST ${expr { TRIGGER_IMAGE_PULL }} --insecure",
         )
     }
+}
+
+fun JobBuilder<JobOutputs.EMPTY>.cleanMavenLocal() {
+    run(
+        name = "Clean Maven Local to fetch required POMs again",
+        command = "rm -rf ~/.m2/repository/"
+    )
 }

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -46,33 +46,39 @@ jobs:
         GHWKT_GITHUB_CONTEXT_JSON: '${{ toJSON(github) }}'
       run: 'GHWKT_RUN_STEP=''end-to-end-test:step-3'' ''.github/workflows/bindings-server.main.kts'''
     - id: 'step-4'
+      name: 'Clean Maven Local to fetch required POMs again'
+      run: 'rm -rf ~/.m2/repository/'
+    - id: 'step-5'
       name: 'Execute the script using the bindings from the serve - with /binding'
       run: |-
         mv .github/workflows/test-script-consuming-jit-bindings-old.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings-old.main.kts
         .github/workflows/test-script-consuming-jit-bindings-old.main.kts
-    - id: 'step-5'
-      name: 'Execute the script using the bindings from the server'
-      run: |-
-        mv .github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings.main.kts
-        .github/workflows/test-script-consuming-jit-bindings.main.kts
     - id: 'step-6'
       name: 'Clean Maven Local to fetch required POMs again'
       run: 'rm -rf ~/.m2/repository/'
     - id: 'step-7'
+      name: 'Execute the script using the bindings from the server'
+      run: |-
+        mv .github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings.main.kts
+        .github/workflows/test-script-consuming-jit-bindings.main.kts
+    - id: 'step-8'
+      name: 'Clean Maven Local to fetch required POMs again'
+      run: 'rm -rf ~/.m2/repository/'
+    - id: 'step-9'
       name: 'Execute the script using bindings but without dependency on library'
       run: |-
         mv .github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts .github/workflows/test-served-bindings-depend-on-library.main.kts
         .github/workflows/test-served-bindings-depend-on-library.main.kts
-    - id: 'step-8'
+    - id: 'step-10'
       name: 'Fetch maven-metadata.xml for top-level action - with /binding'
       run: 'curl --fail http://localhost:8080/binding/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-9'
+    - id: 'step-11'
       name: 'Fetch maven-metadata.xml for nested action - with /binding'
       run: 'curl --fail http://localhost:8080/binding/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-10'
+    - id: 'step-12'
       name: 'Fetch maven-metadata.xml for top-level action'
       run: 'curl --fail http://localhost:8080/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-11'
+    - id: 'step-13'
       name: 'Fetch maven-metadata.xml for nested action'
       run: 'curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
   deploy:


### PR DESCRIPTION
All compilations happen on the same machine, and share the contents of `~/.m2` directory. If we don't clean it, we reuse fetched libraries from previous compilations. It's undesired because e.g. the main script was compiled with the prod bindings server, but next compilations use a server instance started locally.