### PR TITLE
fix(abg): use the release date of the latest version for lastUpdated

### DIFF
--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuilding.kt
@@ -1,8 +1,6 @@
 package io.github.typesafegithub.workflows.mavenbinding
 
 import io.github.typesafegithub.workflows.shared.internal.fetchAvailableVersions
-import java.time.Instant
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 internal suspend fun buildMavenMetadataFile(
@@ -10,15 +8,14 @@ internal suspend fun buildMavenMetadataFile(
     name: String,
     githubToken: String,
 ): String {
-    val lastUpdated =
-        DateTimeFormatter
-            .ofPattern("yyyyMMddHHmmss")
-            .withZone(ZoneId.systemDefault())
-            .format(Instant.now())
     val availableMajorVersions =
         fetchAvailableVersions(owner = owner, name = name.substringBefore("__"), githubToken = githubToken)
             .filter { it.isMajorVersion() }
     val newest = availableMajorVersions.max()
+    val lastUpdated =
+        DateTimeFormatter
+            .ofPattern("yyyyMMddHHmmss")
+            .format(newest.getReleaseDate())
     return """
         <?xml version="1.0" encoding="UTF-8"?>
         <metadata>

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/model/Version.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/model/Version.kt
@@ -1,7 +1,10 @@
 package io.github.typesafegithub.workflows.shared.internal.model
 
+import java.time.ZonedDateTime
+
 data class Version(
     val version: String,
+    private val dateProvider: suspend () -> ZonedDateTime? = { null },
 ) : Comparable<Version> {
     val input: String = version.removePrefix("v").removePrefix("V")
     val major = input.substringBefore(".").toIntOrNull() ?: 0
@@ -23,4 +26,6 @@ data class Version(
     override fun toString(): String = version
 
     fun isMajorVersion(): Boolean = version.contains(".").not()
+
+    suspend fun getReleaseDate() = dateProvider()
 }


### PR DESCRIPTION
This makes the metadata file content more stable and allows to provide a checksum,
as Kotlin for example is quite unhappy if it finds no checksum or cannot successfully verify it.

Without this every request would produce a different file and thus also a different checksum file,
so the checksum would never match the file contents.
