### PR TITLE
perf(abg): create JARs only when they are actually requested

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
@@ -109,10 +109,10 @@ private fun Route.artifact(
         val file = call.parameters["file"]!!
         if (file in bindingArtifacts) {
             when (val artifact = bindingArtifacts[file]) {
-                is TextArtifact -> call.respondText(artifact.data)
+                is TextArtifact -> call.respondText(text = artifact.data())
                 is JarArtifact ->
                     call.respondBytes(
-                        bytes = artifact.data,
+                        bytes = artifact.data(),
                         contentType = ContentType.parse("application/java-archive"),
                     )
 

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/VersionArtifactsBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/VersionArtifactsBuilding.kt
@@ -5,11 +5,11 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCo
 sealed interface Artifact
 
 data class TextArtifact(
-    val data: String,
+    val data: () -> String,
 ) : Artifact
 
 data class JarArtifact(
-    val data: ByteArray,
+    val data: () -> ByteArray,
 ) : Artifact
 
 fun ActionCoords.buildVersionArtifacts(): Map<String, Artifact>? {
@@ -18,12 +18,12 @@ fun ActionCoords.buildVersionArtifacts(): Map<String, Artifact>? {
     val module = buildModuleFile(owner = owner, name = name.replace("__", "/"), version = version)
     return mapOf(
         "$name-$version.jar" to JarArtifact(jars.mainJar),
-        "$name-$version.jar.md5" to TextArtifact(jars.mainJar.md5Checksum()),
+        "$name-$version.jar.md5" to TextArtifact { jars.mainJar().md5Checksum() },
         "$name-$version-sources.jar" to JarArtifact(jars.sourcesJar),
-        "$name-$version-sources.jar.md5" to TextArtifact(jars.sourcesJar.md5Checksum()),
-        "$name-$version.pom" to TextArtifact(pom),
-        "$name-$version.pom.md5" to TextArtifact(pom.md5Checksum()),
-        "$name-$version.module" to TextArtifact(module),
-        "$name-$version.module.md5" to TextArtifact(module.md5Checksum()),
+        "$name-$version-sources.jar.md5" to TextArtifact { jars.sourcesJar().md5Checksum() },
+        "$name-$version.pom" to TextArtifact { pom },
+        "$name-$version.pom.md5" to TextArtifact { pom.md5Checksum() },
+        "$name-$version.module" to TextArtifact { module },
+        "$name-$version.module.md5" to TextArtifact { module.md5Checksum() },
     )
 }


### PR DESCRIPTION
In some cases, only e.g. a POM is necessary to fetch for a given action. Thanks to this change, no Kotlin compilation or JAR creation will happen when requesting an artifact that doesn't require it.