### PR TITLE
fix(abg): reinstate public copy method in binding classes

### DIFF
--- a/.github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts
+++ b/.github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts
@@ -28,3 +28,6 @@ println(Checkout(fetchTags_Untyped = "false"))
 println(AlwaysUntypedActionForTests_Untyped(foobar_Untyped = "baz"))
 println(ActionsSetupGradle())
 println(Cache(path = listOf("some-path"), key = "some-key"))
+
+// Ensure that 'copy(...)' method is exposed.
+Checkout(fetchTags = false).copy(fetchTags = true)

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
@@ -390,7 +390,7 @@ private fun TypeSpec.Builder.replaceWith(replaceWith: CodeBlock?): TypeSpec.Buil
 private fun TypeSpec.Builder.addClassConstructorAnnotation(): TypeSpec.Builder {
     addAnnotation(
         AnnotationSpec
-            .builder(ConsistentCopyVisibility::class.asClassName())
+            .builder(ExposedCopyVisibility::class.asClassName())
             .build(),
     )
     return this

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithAllTypesOfInputs.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithAllTypesOfInputs.kt
@@ -12,7 +12,7 @@ import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
 import kotlin.Boolean
-import kotlin.ConsistentCopyVisibility
+import kotlin.ExposedCopyVisibility
 import kotlin.Float
 import kotlin.Int
 import kotlin.String
@@ -59,7 +59,7 @@ import kotlin.collections.toTypedArray
  * @param _customVersion Allows overriding action's version, for example to use a specific minor
  * version, or a newer version that the binding doesn't yet know about
  */
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithAllTypesOfInputs private constructor(
     /**
      * &lt;required&gt; Short description

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithAllTypesOfInputsTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithAllTypesOfInputsTest.kt
@@ -141,4 +141,29 @@ class ActionWithAllTypesOfInputsTest : DescribeSpec({
             }
         exception.message shouldBe "Only listStrings or listStrings_Untyped must be set, but not both"
     }
+
+    it("exposes copy method") {
+        // given
+        val action = ActionWithAllTypesOfInputs(
+            fooBar = "test",
+            bazGoo = true,
+            binKin = false,
+            intPint = 43,
+            floPint = 123.456f,
+            finBin = ActionWithAllTypesOfInputs.Bin.BooBar,
+            gooZen = ActionWithAllTypesOfInputs.Zen.Special1,
+            bahEnum = ActionWithAllTypesOfInputs.BahEnum.HelloWorld,
+            listStrings = listOf("hello", "world"),
+            listInts = listOf(1, 42),
+            listEnums = listOf(ActionWithAllTypesOfInputs.MyEnum.One, ActionWithAllTypesOfInputs.MyEnum.Three),
+            listIntSpecial = listOf(ActionWithAllTypesOfInputs.MyInt.TheAnswer, ActionWithAllTypesOfInputs.MyInt.Value(0))
+        )
+
+        // when
+        @Suppress("DATA_CLASS_INVISIBLE_COPY_USAGE_WARNING")
+        val actionWithOneChange = action.copy(fooBar = "another")
+
+        // then
+        actionWithOneChange.fooBar shouldBe "another"
+    }
 })

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithAllTypesOfInputs_Untyped.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithAllTypesOfInputs_Untyped.kt
@@ -11,8 +11,8 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
 import kotlin.Deprecated
+import kotlin.ExposedCopyVisibility
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -68,7 +68,7 @@ import kotlin.collections.toTypedArray
     "Use the typed class instead",
     ReplaceWith("ActionWithAllTypesOfInputs"),
 )
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithAllTypesOfInputs_Untyped private constructor(
     /**
      * Short description

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithDeprecatedInputAndNameClash.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithDeprecatedInputAndNameClash.kt
@@ -11,7 +11,7 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
+import kotlin.ExposedCopyVisibility
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -33,7 +33,7 @@ import kotlin.collections.toTypedArray
  * @param _customVersion Allows overriding action's version, for example to use a specific minor
  * version, or a newer version that the binding doesn't yet know about
  */
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithDeprecatedInputAndNameClash private constructor(
     /**
      * &lt;required&gt; Foo bar - new

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithFancyCharsInDocs.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithFancyCharsInDocs.kt
@@ -11,7 +11,7 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
+import kotlin.ExposedCopyVisibility
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -35,7 +35,7 @@ import kotlin.collections.toTypedArray
  * @param _customVersion Allows overriding action's version, for example to use a specific minor
  * version, or a newer version that the binding doesn't yet know about
  */
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithFancyCharsInDocs private constructor(
     /**
      * This is a /&#42; test &#42;/

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithInputsSharingType.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithInputsSharingType.kt
@@ -11,7 +11,7 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
+import kotlin.ExposedCopyVisibility
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
@@ -36,7 +36,7 @@ import kotlin.collections.toTypedArray
  * @param _customVersion Allows overriding action's version, for example to use a specific minor
  * version, or a newer version that the binding doesn't yet know about
  */
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithInputsSharingType private constructor(
     /**
      * &lt;required&gt;

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithNoInputs.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithNoInputs.kt
@@ -11,7 +11,7 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
+import kotlin.ExposedCopyVisibility
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -29,7 +29,7 @@ import kotlin.collections.Map
  * @param _customVersion Allows overriding action's version, for example to use a specific minor
  * version, or a newer version that the binding doesn't yet know about
  */
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithNoInputs private constructor(
     /**
      * Type-unsafe map where you can put any inputs that are not yet supported by the binding

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithNoTypings_Untyped.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithNoTypings_Untyped.kt
@@ -11,7 +11,7 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
+import kotlin.ExposedCopyVisibility
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -51,7 +51,7 @@ import kotlin.collections.toTypedArray
  * @param _customVersion Allows overriding action's version, for example to use a specific minor
  * version, or a newer version that the binding doesn't yet know about
  */
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithNoTypings_Untyped private constructor(
     public val foo_Untyped: String,
     public val bar_Untyped: String? = null,

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithOutputs.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithOutputs.kt
@@ -11,7 +11,7 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
+import kotlin.ExposedCopyVisibility
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -33,7 +33,7 @@ import kotlin.collections.toTypedArray
  * @param _customVersion Allows overriding action's version, for example to use a specific minor
  * version, or a newer version that the binding doesn't yet know about
  */
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithOutputs private constructor(
     /**
      * &lt;required&gt; Short description

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithPartlyTypings.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithPartlyTypings.kt
@@ -11,7 +11,7 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
+import kotlin.ExposedCopyVisibility
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
@@ -34,7 +34,7 @@ import kotlin.collections.toTypedArray
  * @param _customVersion Allows overriding action's version, for example to use a specific minor
  * version, or a newer version that the binding doesn't yet know about
  */
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithPartlyTypings private constructor(
     /**
      * &lt;required&gt;

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithPartlyTypings_Untyped.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithPartlyTypings_Untyped.kt
@@ -11,8 +11,8 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
 import kotlin.Deprecated
+import kotlin.ExposedCopyVisibility
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -56,7 +56,7 @@ import kotlin.collections.toTypedArray
     "Use the typed class instead",
     ReplaceWith("ActionWithPartlyTypings"),
 )
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithPartlyTypings_Untyped private constructor(
     public val foo_Untyped: String,
     public val bar_Untyped: String? = null,

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithSomeOptionalInputs.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithSomeOptionalInputs.kt
@@ -11,7 +11,7 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
+import kotlin.ExposedCopyVisibility
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -41,7 +41,7 @@ import kotlin.collections.toTypedArray
  * @param _customVersion Allows overriding action's version, for example to use a specific minor
  * version, or a newer version that the binding doesn't yet know about
  */
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class ActionWithSomeOptionalInputs private constructor(
     /**
      * Required is default, default is set

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/SimpleActionWithRequiredStringInputs.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/SimpleActionWithRequiredStringInputs.kt
@@ -12,8 +12,8 @@ package io.github.typesafegithub.workflows.actions.johnsmith
 import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
 import java.util.LinkedHashMap
-import kotlin.ConsistentCopyVisibility
 import kotlin.Deprecated
+import kotlin.ExposedCopyVisibility
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -40,7 +40,7 @@ import kotlin.collections.toTypedArray
  * @param _customVersion Allows overriding action's version, for example to use a specific minor
  * version, or a newer version that the binding doesn't yet know about
  */
-@ConsistentCopyVisibility
+@ExposedCopyVisibility
 public data class SimpleActionWithRequiredStringInputs private constructor(
     /**
      * &lt;required&gt; Short description


### PR DESCRIPTION
Fixes #1626.

A long-term approach is tracked in https://github.com/typesafegithub/github-workflows-kt/issues/1629.