### PR TITLE
docs: clarify that still YAML files are generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License](https://img.shields.io/github/license/typesafegithub/github-workflows-kt)](https://github.com/typesafegithub/github-workflows-kt/blob/main/LICENSE)
 [![github-workflows-kt @ kotlinlang.slack.com](https://img.shields.io/static/v1?label=kotlinlang&message=github-workflows-kt&color=blue&logo=slack)](https://kotlinlang.slack.com/archives/C02UUATR7RC)
 
-[github-workflows-kt](https://github.com/typesafegithub/github-workflows-kt/) is a tool for creating
-[GitHub Actions workflows](https://docs.github.com/en/actions/using-workflows) in a **type-safe** script, helping you to
+[github-workflows-kt](https://github.com/typesafegithub/github-workflows-kt/) is a tool for generating
+[GitHub Actions workflow](https://docs.github.com/en/actions/using-workflows) YAML files in a **type-safe** script, helping you to
 build **robust** workflows for your GitHub projects without mistakes, with **pleasure**, in
 [Kotlin](https://kotlinlang.org/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # github-workflows-kt
 
-github-workflows-kt is a tool for creating
-[GitHub Actions workflows](https://docs.github.com/en/actions/using-workflows) in a **type-safe** script, helping you to
+github-workflows-kt is a tool for generating
+[GitHub Actions workflow](https://docs.github.com/en/actions/using-workflows) YAML files in a **type-safe** script, helping you to
 build **robust** workflows for your GitHub projects without mistakes, with **pleasure**, in
 [Kotlin](https://kotlinlang.org/).
 


### PR DESCRIPTION
Be more clear about the "two-step approach" that still requires YAML files to be generated underneath, which serve as the definition of workflows. This should help to avoid the impression that the project can be used as a complete substitute for using YAML files at all.