### PR TITLE
refactor: unify content of ActionCoords name

### DIFF
--- a/action-binding-generator/api/action-binding-generator.api
+++ b/action-binding-generator/api/action-binding-generator.api
@@ -1,21 +1,24 @@
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOwner ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoordsKt {
+	public static final fun getFullName (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;)Ljava/lang/String;
 	public static final fun getPrettyPrint (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;)Ljava/lang/String;
-	public static final fun getRepoName (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;)Ljava/lang/String;
 	public static final fun getSubName (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;)Ljava/lang/String;
 	public static final fun isTopLevel (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;)Z
 }

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords.kt
@@ -4,37 +4,39 @@ public data class ActionCoords(
     val owner: String,
     val name: String,
     val version: String,
+    val path: String? = null,
 )
 
 /**
  * A top-level action is an action with its `action.y(a)ml` file in the repository root, as opposed to actions stored
  * in subdirectories.
  */
-public val ActionCoords.isTopLevel: Boolean get() = "/" !in name
+public val ActionCoords.isTopLevel: Boolean get() = path == null
 
-public val ActionCoords.prettyPrint: String get() = "$owner/$name@$version"
-
-/**
- * For most actions, it's the same as [ActionCoords.name].
- * For actions that aren't executed from the root of the repo, it returns the repo name.
- */
-public val ActionCoords.repoName: String get() =
-    name.substringBefore("/")
+public val ActionCoords.prettyPrint: String get() = "$owner/$fullName@$version"
 
 /**
  * For most actions, it's empty.
  * For actions that aren't executed from the root of the repo, it returns the path relative to the repo root where the
+ * action lives, starting with a slash.
+ */
+public val ActionCoords.subName: String get() = path?.let { "/$path" } ?: ""
+
+/**
+ * For most actions, it's equal to [ActionCoords.name].
+ * For actions that aren't executed from the root of the repo, it returns the path starting with the repo root where the
  * action lives.
  */
-public val ActionCoords.subName: String get() =
-    if (isTopLevel) "" else "/${name.substringAfter("/")}"
+public val ActionCoords.fullName: String get() = "$name$subName"
 
 internal fun String.toActionCoords(): ActionCoords {
-    val (ownerAndName, version) = this.split('@')
-    val (owner, name) = ownerAndName.split('/', limit = 2)
+    val (coordinates, version) = this.split('@')
+    val coordinateParts = coordinates.split('/')
+    val (owner, name) = coordinateParts
     return ActionCoords(
         owner = owner,
         name = name,
         version = version,
+        path = coordinateParts.drop(2).joinToString("/").takeUnless { it.isBlank() },
     )
 }

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/ClassNaming.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/ClassNaming.kt
@@ -1,6 +1,7 @@
 package io.github.typesafegithub.workflows.actionbindinggenerator.generation
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.fullName
 import io.github.typesafegithub.workflows.actionbindinggenerator.utils.toPascalCase
 
-internal fun ActionCoords.buildActionClassName(): String = this.name.toPascalCase()
+internal fun ActionCoords.buildActionClassName(): String = this.fullName.toPascalCase()

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
@@ -18,6 +18,9 @@ import com.squareup.kotlinpoet.buildCodeBlock
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.MetadataRevision
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.fullName
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.isTopLevel
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.subName
 import io.github.typesafegithub.workflows.actionbindinggenerator.generation.Properties.CUSTOM_INPUTS
 import io.github.typesafegithub.workflows.actionbindinggenerator.generation.Properties.CUSTOM_VERSION
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.Input
@@ -411,7 +414,7 @@ private fun TypeSpec.Builder.inheritsFromRegularAction(
     return this
         .superclass(superclass)
         .addSuperclassConstructorParameter("%S", coords.owner)
-        .addSuperclassConstructorParameter("%S", coords.name)
+        .addSuperclassConstructorParameter("%S", coords.fullName)
         .addSuperclassConstructorParameter("_customVersion ?: %S", coords.version)
 }
 
@@ -614,9 +617,7 @@ private fun actionKdoc(
        |
        |${metadata.description.escapedForComments.removeTrailingWhitespacesForEachLine()}
        |
-       |[Action on GitHub](https://github.com/${coords.owner}/${coords.name.substringBefore(
-        '/',
-    )}${if ("/" in coords.name) "/tree/${coords.version}/${coords.name.substringAfter('/')}" else ""})
+       |[Action on GitHub](https://github.com/${coords.owner}/${coords.name}${if (coords.isTopLevel) "" else "/tree/${coords.version}${coords.subName}"})
     """.trimMargin()
 
 private fun Map<String, Typing>?.getInputTyping(key: String) = this?.get(key) ?: StringTyping

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/metadata/MetadataReading.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/metadata/MetadataReading.kt
@@ -5,6 +5,7 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCo
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.CommitHash
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.MetadataRevision
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestForVersion
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.subName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import java.io.IOException
@@ -35,15 +36,9 @@ public data class Output(
     val description: String = "",
 )
 
-private fun ActionCoords.actionYmlUrl(gitRef: String) =
-    "https://raw.githubusercontent.com/$owner/${name.substringBefore(
-        '/',
-    )}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yml"
+private fun ActionCoords.actionYmlUrl(gitRef: String) = "https://raw.githubusercontent.com/$owner/$name/$gitRef$subName/action.yml"
 
-private fun ActionCoords.actionYamlUrl(gitRef: String) =
-    "https://raw.githubusercontent.com/$owner/${name.substringBefore(
-        '/',
-    )}/$gitRef/${if ("/" in name) "${name.substringAfter('/')}/" else ""}action.yaml"
+private fun ActionCoords.actionYamlUrl(gitRef: String) = "https://raw.githubusercontent.com/$owner/$name/$gitRef$subName/action.yaml"
 
 internal val ActionCoords.gitHubUrl: String get() = "https://github.com/$owner/$name"
 

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
@@ -8,7 +8,6 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestFo
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource.ACTION
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource.TYPING_CATALOG
-import io.github.typesafegithub.workflows.actionbindinggenerator.domain.repoName
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.subName
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.fetchUri
 import io.github.typesafegithub.workflows.actionbindinggenerator.utils.toPascalCase
@@ -29,18 +28,18 @@ internal fun ActionCoords.provideTypes(
         ?: Pair(emptyMap(), null)
 
 private fun ActionCoords.actionTypesYmlUrl(gitRef: String) =
-    "https://raw.githubusercontent.com/$owner/$repoName/$gitRef$subName/action-types.yml"
+    "https://raw.githubusercontent.com/$owner/$name/$gitRef$subName/action-types.yml"
 
 private fun ActionCoords.actionTypesFromCatalog() =
     "https://raw.githubusercontent.com/typesafegithub/github-actions-typing-catalog/" +
-        "main/typings/$owner/$repoName/$version$subName/action-types.yml"
+        "main/typings/$owner/$name/$version$subName/action-types.yml"
 
 private fun ActionCoords.catalogMetadata() =
     "https://raw.githubusercontent.com/typesafegithub/github-actions-typing-catalog/" +
-        "main/typings/$owner/$repoName/metadata.yml"
+        "main/typings/$owner/$name/metadata.yml"
 
 private fun ActionCoords.actionTypesYamlUrl(gitRef: String) =
-    "https://raw.githubusercontent.com/$owner/$repoName/$gitRef$subName/action-types.yaml"
+    "https://raw.githubusercontent.com/$owner/$name/$gitRef$subName/action-types.yaml"
 
 private fun ActionCoords.fetchTypingMetadata(
     metadataRevision: MetadataRevision,

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithSubAction.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithSubAction.kt
@@ -1,0 +1,51 @@
+// This file was generated using action-binding-generator. Don't change it by hand, otherwise your
+// changes will be overwritten with the next binding code regeneration.
+// See https://github.com/typesafegithub/github-workflows-kt for more info.
+@file:Suppress(
+    "DataClassPrivateConstructor",
+    "UNUSED_PARAMETER",
+)
+
+package io.github.typesafegithub.workflows.actions.johnsmith
+
+import io.github.typesafegithub.workflows.domain.actions.Action
+import io.github.typesafegithub.workflows.domain.actions.RegularAction
+import java.util.LinkedHashMap
+import kotlin.ExposedCopyVisibility
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+
+/**
+ * Action: Action With No Inputs
+ *
+ * Description
+ *
+ * [Action on GitHub](https://github.com/john-smith/action-with/tree/v3/sub/action)
+ *
+ * @param _customInputs Type-unsafe map where you can put any inputs that are not yet supported by the binding
+ * @param _customVersion Allows overriding action's version, for example to use a specific minor version, or a newer version that the binding doesn't yet know about
+ */
+@ExposedCopyVisibility
+public data class ActionWithSubAction private constructor(
+    /**
+     * Type-unsafe map where you can put any inputs that are not yet supported by the binding
+     */
+    public val _customInputs: Map<String, String> = mapOf(),
+    /**
+     * Allows overriding action's version, for example to use a specific minor version, or a newer version that the binding doesn't yet know about
+     */
+    public val _customVersion: String? = null,
+) : RegularAction<Action.Outputs>("john-smith", "action-with/sub/action", _customVersion ?: "v3") {
+    public constructor(
+        vararg pleaseUseNamedArguments: Unit,
+        _customInputs: Map<String, String> = mapOf(),
+        _customVersion: String? = null,
+    ) : this(_customInputs = _customInputs, _customVersion = _customVersion)
+
+    @Suppress("SpreadOperator")
+    override fun toYamlArguments(): LinkedHashMap<String, String> = LinkedHashMap(_customInputs)
+
+    override fun buildOutputObject(stepId: String): Action.Outputs = Outputs(stepId)
+}

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/ClassNamingTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/ClassNamingTest.kt
@@ -9,8 +9,8 @@ class ClassNamingTest :
         context("buildActionClassName") {
             listOf(
                 ActionCoords("irrelevant", "some-action-name", "v2") to "SomeActionName",
-                ActionCoords("irrelevant", "some-action-name/subaction", "v2") to "SomeActionNameSubaction",
-                ActionCoords("irrelevant", "some-action-name/foo/bar/baz", "v2") to "SomeActionNameFooBarBaz",
+                ActionCoords("irrelevant", "some-action-name", "v2", "subaction") to "SomeActionNameSubaction",
+                ActionCoords("irrelevant", "some-action-name", "v2", "foo/bar/baz") to "SomeActionNameFooBarBaz",
             ).forEach { (input, output) ->
                 test("should get '$input' and produce '$output'") {
                     input.buildActionClassName() shouldBe output

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -287,6 +287,30 @@ class GenerationTest :
             binding.shouldContainAndMatchFile("ActionWithNoInputs.kt")
         }
 
+        test("subaction") {
+            // given
+            val actionManifestHasNoInputs = emptyMap<String, Input>()
+            val actionManifest =
+                Metadata(
+                    inputs = actionManifestHasNoInputs,
+                    name = "Action With No Inputs",
+                    description = "Description",
+                )
+
+            val coords = ActionCoords("john-smith", "action-with", "v3", "sub/action")
+
+            // when
+            val binding =
+                coords.generateBinding(
+                    metadataRevision = NewestForVersion,
+                    metadata = actionManifest,
+                    inputTypings = Pair(emptyMap(), ACTION),
+                )
+
+            // then
+            binding.shouldContainAndMatchFile("ActionWithSubAction.kt")
+        }
+
         test("action with deprecated input resolving to the same Kotlin field name") {
             // given
             val actionManifest =

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
@@ -129,7 +129,7 @@ class TypesProvidingTest :
                         else -> throw IOException()
                     }
                 }
-                val actionCoord = ActionCoords("some-owner", "some-name/some-sub", "v3")
+                val actionCoord = ActionCoords("some-owner", "some-name", "v3", "some-sub")
 
                 // When
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
@@ -166,7 +166,7 @@ class TypesProvidingTest :
                         else -> throw IOException()
                     }
                 }
-                val actionCoord = ActionCoords("some-owner", "some-name/some-sub", "v3")
+                val actionCoord = ActionCoords("some-owner", "some-name", "v3", "some-sub")
 
                 // When
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
@@ -208,7 +208,7 @@ class TypesProvidingTest :
                         else -> throw IOException()
                     }
                 }
-                val actionCoord = ActionCoords("some-owner", "some-name/some-sub", "v3")
+                val actionCoord = ActionCoords("some-owner", "some-name", "v3", "some-sub")
 
                 // When
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
@@ -250,7 +250,7 @@ class TypesProvidingTest :
                         else -> throw IOException()
                     }
                 }
-                val actionCoord = ActionCoords("some-owner", "some-name/some-sub", "v3")
+                val actionCoord = ActionCoords("some-owner", "some-name", "v3", "some-sub")
 
                 // When
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
@@ -302,7 +302,7 @@ class TypesProvidingTest :
                         else -> throw IOException()
                     }
                 }
-                val actionCoord = ActionCoords("some-owner", "some-name/some-sub", "v3")
+                val actionCoord = ActionCoords("some-owner", "some-name", "v3", "some-sub")
 
                 // When
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
@@ -354,7 +354,7 @@ class TypesProvidingTest :
                         else -> throw IOException()
                     }
                 }
-                val actionCoord = ActionCoords("some-owner", "some-name/some-sub", "v6")
+                val actionCoord = ActionCoords("some-owner", "some-name", "v6", "some-sub")
 
                 // When
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)

--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
@@ -72,13 +72,15 @@ private fun Route.metadata(refresh: Boolean = false) {
         }
 
         val owner = call.parameters["owner"]!!
-        val name = call.parameters["name"]!!
+        val nameAndPath = call.parameters["name"]!!.split("__")
+        val name = nameAndPath.first()
         val file = call.parameters["file"]!!
         val actionCoords =
             ActionCoords(
                 owner = owner,
                 name = name,
                 version = "irrelevant",
+                path = nameAndPath.drop(1).joinToString("/").takeUnless { it.isBlank() },
             )
         val bindingArtifacts = actionCoords.buildPackageArtifacts(githubToken = getGithubToken())
         if (file in bindingArtifacts) {
@@ -143,13 +145,15 @@ private suspend fun ApplicationCall.toBindingArtifacts(
     refresh: Boolean,
 ): Map<String, Artifact>? {
     val owner = parameters["owner"]!!
-    val name = parameters["name"]!!
+    val nameAndPath = parameters["name"]!!.split("__")
+    val name = nameAndPath.first()
     val version = parameters["version"]!!
     val actionCoords =
         ActionCoords(
             owner = owner,
             name = name,
             version = version,
+            path = nameAndPath.drop(1).joinToString("/").takeUnless { it.isBlank() },
         )
     println("➡️ Requesting ${actionCoords.prettyPrint}")
     val bindingArtifacts =

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/ActionCoordsUtils.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/ActionCoordsUtils.kt
@@ -1,0 +1,6 @@
+package io.github.typesafegithub.workflows.mavenbinding
+
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.subName
+
+internal val ActionCoords.mavenName: String get() = "$name${subName.replace("/", "__")}"

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/JarBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/JarBuilding.kt
@@ -26,13 +26,9 @@ internal data class Jars(
     val sourcesJar: () -> ByteArray,
 )
 
-internal fun buildJars(
-    owner: String,
-    name: String,
-    version: String,
-): Jars? {
+internal fun ActionCoords.buildJars(): Jars? {
     val binding =
-        generateBinding(owner = owner, name = name, version = version).also {
+        generateBinding(metadataRevision = NewestForVersion).also {
             if (it.isEmpty()) return null
         }
 
@@ -57,22 +53,6 @@ internal fun buildJars(
     return Jars(
         mainJar = { mainJar },
         sourcesJar = { sourcesJar },
-    )
-}
-
-private fun generateBinding(
-    owner: String,
-    name: String,
-    version: String,
-): List<ActionBinding> {
-    val actionCoords =
-        ActionCoords(
-            owner = owner,
-            name = name,
-            version = version,
-        )
-    return actionCoords.generateBinding(
-        metadataRevision = NewestForVersion,
     )
 }
 

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuilding.kt
@@ -1,15 +1,13 @@
 package io.github.typesafegithub.workflows.mavenbinding
 
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.fullName
 import io.github.typesafegithub.workflows.shared.internal.fetchAvailableVersions
 import java.time.format.DateTimeFormatter
 
-internal suspend fun buildMavenMetadataFile(
-    owner: String,
-    name: String,
-    githubToken: String,
-): String {
+internal suspend fun ActionCoords.buildMavenMetadataFile(githubToken: String): String {
     val availableMajorVersions =
-        fetchAvailableVersions(owner = owner, name = name.substringBefore("__"), githubToken = githubToken)
+        fetchAvailableVersions(owner = owner, name = name, githubToken = githubToken)
             .filter { it.isMajorVersion() }
     val newest = availableMajorVersions.max()
     val lastUpdated =
@@ -20,7 +18,7 @@ internal suspend fun buildMavenMetadataFile(
         <?xml version="1.0" encoding="UTF-8"?>
         <metadata>
           <groupId>$owner</groupId>
-          <artifactId>${name.replace("__", "/")}</artifactId>
+          <artifactId>$fullName</artifactId>
           <versioning>
             <latest>$newest</latest>
             <release>$newest</release>

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/ModuleBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/ModuleBuilding.kt
@@ -1,16 +1,15 @@
 package io.github.typesafegithub.workflows.mavenbinding
 
-internal fun buildModuleFile(
-    owner: String,
-    name: String,
-    version: String,
-): String =
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.fullName
+
+internal fun ActionCoords.buildModuleFile() =
     """
     {
       "formatVersion": "1.1",
       "component": {
         "group": "$owner",
-        "module": "$name",
+        "module": "$fullName",
         "version": "$version",
         "attributes": {
           "org.gradle.status": "release"
@@ -36,8 +35,8 @@ internal fun buildModuleFile(
           "dependencies": [],
           "files": [
             {
-              "name": "$name-$version.jar",
-              "url": "$name-$version.jar",
+              "name": "$fullName-$version.jar",
+              "url": "$fullName-$version.jar",
               "size": 1
             }
           ]
@@ -56,8 +55,8 @@ internal fun buildModuleFile(
           "dependencies": [],
           "files": [
             {
-              "name": "$name-$version.jar",
-              "url": "$name-$version.jar",
+              "name": "$fullName-$version.jar",
+              "url": "$fullName-$version.jar",
               "size": 1
             }
           ]

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PackageArtifactsBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PackageArtifactsBuilding.kt
@@ -3,7 +3,7 @@ package io.github.typesafegithub.workflows.mavenbinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 
 suspend fun ActionCoords.buildPackageArtifacts(githubToken: String): Map<String, String> {
-    val mavenMetadata = buildMavenMetadataFile(owner = owner, name = name, githubToken = githubToken)
+    val mavenMetadata = buildMavenMetadataFile(githubToken = githubToken)
     return mapOf(
         "maven-metadata.xml" to mavenMetadata,
         "maven-metadata.xml.md5" to mavenMetadata.md5Checksum(),

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PomBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PomBuilding.kt
@@ -1,36 +1,34 @@
 package io.github.typesafegithub.workflows.mavenbinding
 
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.fullName
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.prettyPrint
+
 internal const val LATEST_RELASED_LIBRARY_VERSION = "3.0.1"
 
-internal fun buildPomFile(
-    owner: String,
-    name: String,
-    version: String,
-): String {
-    val nameForRepo = name.substringBefore("/")
-    return """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-          <modelVersion>4.0.0</modelVersion>
-          <groupId>$owner</groupId>
-          <artifactId>$name</artifactId>
-          <version>$version</version>
-          <name>$name</name>
-          <description>Auto-generated binding for $owner/$name@$version.</description>
-          <url>https://github.com/$owner/$nameForRepo</url>
-          <scm>
-            <connection>scm:git:git://github.com/$owner/$nameForRepo.git/</connection>
-            <developerConnection>scm:git:ssh://github.com:$owner/$nameForRepo.git</developerConnection>
-            <url>https://github.com/$owner/$nameForRepo.git</url>
-          </scm>
-          <dependencies>
-            <dependency>
-                <groupId>io.github.typesafegithub</groupId>
-                <artifactId>github-workflows-kt</artifactId>
-                <version>$LATEST_RELASED_LIBRARY_VERSION</version>
-                <scope>compile</scope>
-            </dependency>
-          </dependencies>
-        </project>
-        """.trimIndent()
-}
+internal fun ActionCoords.buildPomFile() =
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <modelVersion>4.0.0</modelVersion>
+      <groupId>$owner</groupId>
+      <artifactId>$fullName</artifactId>
+      <version>$version</version>
+      <name>$fullName</name>
+      <description>Auto-generated binding for $prettyPrint.</description>
+      <url>https://github.com/$owner/$name</url>
+      <scm>
+        <connection>scm:git:git://github.com/$owner/$name.git/</connection>
+        <developerConnection>scm:git:ssh://github.com:$owner/$name.git</developerConnection>
+        <url>https://github.com/$owner/$name.git</url>
+      </scm>
+      <dependencies>
+        <dependency>
+            <groupId>io.github.typesafegithub</groupId>
+            <artifactId>github-workflows-kt</artifactId>
+            <version>$LATEST_RELASED_LIBRARY_VERSION</version>
+            <scope>compile</scope>
+        </dependency>
+      </dependencies>
+    </project>
+    """.trimIndent()

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/VersionArtifactsBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/VersionArtifactsBuilding.kt
@@ -13,17 +13,17 @@ data class JarArtifact(
 ) : Artifact
 
 fun ActionCoords.buildVersionArtifacts(): Map<String, Artifact>? {
-    val jars = buildJars(owner = owner, name = name.replace("__", "/"), version = version) ?: return null
-    val pom = buildPomFile(owner = owner, name = name.replace("__", "/"), version = version)
-    val module = buildModuleFile(owner = owner, name = name.replace("__", "/"), version = version)
+    val jars = buildJars() ?: return null
+    val pom = buildPomFile()
+    val module = buildModuleFile()
     return mapOf(
-        "$name-$version.jar" to JarArtifact(jars.mainJar),
-        "$name-$version.jar.md5" to TextArtifact { jars.mainJar().md5Checksum() },
-        "$name-$version-sources.jar" to JarArtifact(jars.sourcesJar),
-        "$name-$version-sources.jar.md5" to TextArtifact { jars.sourcesJar().md5Checksum() },
-        "$name-$version.pom" to TextArtifact { pom },
-        "$name-$version.pom.md5" to TextArtifact { pom.md5Checksum() },
-        "$name-$version.module" to TextArtifact { module },
-        "$name-$version.module.md5" to TextArtifact { module.md5Checksum() },
+        "$mavenName-$version.jar" to JarArtifact(jars.mainJar),
+        "$mavenName-$version.jar.md5" to TextArtifact { jars.mainJar().md5Checksum() },
+        "$mavenName-$version-sources.jar" to JarArtifact(jars.sourcesJar),
+        "$mavenName-$version-sources.jar.md5" to TextArtifact { jars.sourcesJar().md5Checksum() },
+        "$mavenName-$version.pom" to TextArtifact { pom },
+        "$mavenName-$version.pom.md5" to TextArtifact { pom.md5Checksum() },
+        "$mavenName-$version.module" to TextArtifact { module },
+        "$mavenName-$version.module.md5" to TextArtifact { module.md5Checksum() },
     )
 }


### PR DESCRIPTION
Before these changes, `ActionCoords#name` sometimes had the actual action coordinates, so for example `some-name__some-sub`, sometimes it had the replaced `some-name/some-sub`.
This is not good, as you never know what you get and also led to certain bugs where wrong things are written to metadata files for example.
This changes unifies the situation, so that the `name` only contains the repository name and the `path` is in a separate property with slashes.
All other manipulation is then done where needed.