### PR TITLE
fix(server): configure endpoint for OpenTelemetry exporters

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/OpenTelemetryConfig.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/OpenTelemetryConfig.kt
@@ -41,8 +41,8 @@ internal fun buildOpenTelemetryConfig(
             .setTimeout(30, TimeUnit.SECONDS)
             .build()
 
-    val metricExporter = OtlpGrpcMetricExporter.builder().build()
-    val recordExporter = OtlpGrpcLogRecordExporter.builder().build()
+    val metricExporter = OtlpGrpcMetricExporter.builder().setEndpoint(endpointConfig).build()
+    val recordExporter = OtlpGrpcLogRecordExporter.builder().setEndpoint(endpointConfig).build()
 
     val resource =
         Resource


### PR DESCRIPTION
Previously, the OpenTelemetry metric and log record exporters were initialized without specifying an endpoint. This change sets the endpoint configuration for both exporters to ensure they communicate with the correct server.

Without this change, the default endpoint is `localhost`, which won't resolve and thus part of the payload won't be published. This leads to a
 complete failure of metric/telemetry publishing, and it's the reason
 why many metrics are not making their way into Jaeger.

Making the change and running the docker repository locally proved to me
 that no more errors were showing up in the log. Next step is bringing
 it to production