### PR TITLE
fix(abg): handle non-numeric versions gracefully

### DIFF
--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
@@ -80,9 +80,10 @@ private fun ActionCoords.fetchTypingsForOlderVersionFromCatalog(fetchUri: (URI) 
             return null
         }
     val metadata = yaml.decodeFromString<CatalogMetadata>(metadataYml)
+    val requestedVersionAsInt = this.version.versionToIntOrNull() ?: return null
     val fallbackVersion =
         metadata.versionsWithTypings
-            .filter { it.versionToInt() < this.version.versionToInt() }
+            .filter { it.versionToInt() < requestedVersionAsInt }
             .maxByOrNull { it.versionToInt() }
             ?: run {
                 println("  ... no fallback version found!")
@@ -151,7 +152,9 @@ private inline fun <reified T> Yaml.decodeFromStringOrDefaultIfEmpty(
         default
     }
 
-private fun String.versionToInt() = lowercase().removePrefix("v").toInt()
+private fun String.versionToInt() = this.versionToIntOrNull() ?: error("Version '$this' cannot be treated as numeric!")
+
+private fun String.versionToIntOrNull() = lowercase().removePrefix("v").toIntOrNull()
 
 private val yaml =
     Yaml(

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
@@ -509,4 +509,32 @@ class TypesProvidingTest :
                     )
             }
         }
+
+        test("non-numeric version is provided and metadata in typing catalog exists") {
+            // Given
+            val metadata =
+                """
+                "versionsWithTypings":
+                - "v2"
+                - "v3"
+                - "v4"
+                """.trimIndent()
+            val fetchUri: (URI) -> String = {
+                when (it) {
+                    URI(
+                        "https://raw.githubusercontent.com/typesafegithub/github-actions-typing-catalog/" +
+                            "main/typings/some-owner/some-name/metadata.yml",
+                    ),
+                    -> metadata
+                    else -> throw IOException()
+                }
+            }
+            val actionCoord = ActionCoords("some-owner", "some-name", "v6-beta")
+
+            // When
+            val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
+
+            // Then
+            types shouldBe Pair(emptyMap(), null)
+        }
     })


### PR DESCRIPTION
Fixes #1667.

In the logic, we were trying to parse version like `v2-beta` into an
integer. We could generally try to do it, but I think there are too
many possible variations to support them, so let's just support
versions that after removing the leading `v`, gives us an integer.
