### PR TITLE
chore(ci): cache buildSrc/build dir

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -3,6 +3,7 @@
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.0.1")
 
 @file:Repository("https://bindings.krzeminski.it")
+@file:DependsOn("actions:cache:v4")
 @file:DependsOn("actions:checkout:v4")
 @file:DependsOn("actions:setup-java:v4")
 @file:DependsOn("gradle:actions__setup-gradle:v4")
@@ -11,6 +12,7 @@
 @file:Import("setup-java.main.kts")
 @file:Import("setup-python.main.kts")
 
+import io.github.typesafegithub.workflows.actions.actions.Cache
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.actions.SetupJava
 import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
@@ -38,6 +40,10 @@ workflow(
             runsOn = runnerType,
         ) {
             uses(action = Checkout())
+            uses(action = Cache(
+                path = listOf("buildSrc/build"),
+                key = "gradle-buildSrc-build-dir-" + expr { runner.os },
+            ))
             setupJava()
             uses(action = ActionsSetupGradle(
                 cacheEncryptionKey = expr { GRADLE_ENCRYPTION_KEY },

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,16 +30,21 @@ jobs:
     - id: 'step-0'
       uses: 'actions/checkout@v4'
     - id: 'step-1'
+      uses: 'actions/cache@v4'
+      with:
+        path: 'buildSrc/build'
+        key: 'gradle-buildSrc-build-dir-${{ runner.os }}'
+    - id: 'step-2'
       name: 'Set up JDK'
       uses: 'actions/setup-java@v4'
       with:
         java-version: '11'
         distribution: 'zulu'
-    - id: 'step-2'
+    - id: 'step-3'
       uses: 'gradle/actions/setup-gradle@v4'
       with:
         cache-encryption-key: '${{ secrets.GRADLE_ENCRYPTION_KEY }}'
-    - id: 'step-3'
+    - id: 'step-4'
       name: 'Build'
       env:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -52,16 +57,21 @@ jobs:
     - id: 'step-0'
       uses: 'actions/checkout@v4'
     - id: 'step-1'
+      uses: 'actions/cache@v4'
+      with:
+        path: 'buildSrc/build'
+        key: 'gradle-buildSrc-build-dir-${{ runner.os }}'
+    - id: 'step-2'
       name: 'Set up JDK'
       uses: 'actions/setup-java@v4'
       with:
         java-version: '11'
         distribution: 'zulu'
-    - id: 'step-2'
+    - id: 'step-3'
       uses: 'gradle/actions/setup-gradle@v4'
       with:
         cache-encryption-key: '${{ secrets.GRADLE_ENCRYPTION_KEY }}'
-    - id: 'step-3'
+    - id: 'step-4'
       name: 'Build'
       env:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
The goal is to fix restoring configuration cache, because otherwise we're getting:

```
Calculating task graph as configuration cache cannot be reused because an input to task ':buildSrc:compilePluginsBlocks' has changed.
```