### PR TITLE
chore(server): change tracer collector's host name

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/OpenTelemetryConfig.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/OpenTelemetryConfig.kt
@@ -32,7 +32,7 @@ UI available at http://localhost:16686/
 */
 internal fun buildOpenTelemetryConfig(
     serviceName: String,
-    endpointConfig: String = "http://jaeger:4317",
+    endpointConfig: String = "http://traces_collector:4317",
 ): OpenTelemetry {
     val spanExporter =
         OtlpGrpcSpanExporter


### PR DESCRIPTION
We're about to change a service which receives the traces. It's now
Jaeger, and thanks to this change: https://github.com/LeoColman/MyStack/pull/21,
Jaeger is now reachable by the more abstract host name. It lets us
abstract out what component receives the traces by simply configuring
in Docker Compose's config which service will be available under this
hostname. Ultimately, it will allow us to enable aggregated metrics with
OTel Collector and Prometheus without downtime.
