### PR TITLE
chore(abg): remove custom billion laughs attack protection

### DIFF
--- a/action-binding-generator/build.gradle.kts
+++ b/action-binding-generator/build.gradle.kts
@@ -13,7 +13,6 @@ version = rootProject.version
 
 dependencies {
     implementation("com.squareup:kotlinpoet:2.0.0")
-    implementation("it.krzeminski:snakeyaml-engine-kmp:3.0.3")
     implementation("com.charleskorn.kaml:kaml:0.66.0")
     implementation("io.github.oshai:kotlin-logging:7.0.3")
     implementation(projects.sharedInternal)

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
@@ -13,7 +13,6 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingAc
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.subName
 import io.github.typesafegithub.workflows.actionbindinggenerator.metadata.fetchUri
 import io.github.typesafegithub.workflows.actionbindinggenerator.utils.toPascalCase
-import it.krzeminski.snakeyaml.engine.kmp.api.Load
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import java.io.IOException
@@ -83,7 +82,7 @@ private fun ActionCoords.fetchTypingsForOlderVersionFromCatalog(fetchUri: (URI) 
         } catch (e: IOException) {
             return null
         }
-    val metadata = yaml.protectedDecodeFromString<CatalogMetadata>(metadataYml)
+    val metadata = yaml.decodeFromString<CatalogMetadata>(metadataYml)
     val requestedVersionAsInt = this.version.versionToIntOrNull() ?: return null
     val fallbackVersion =
         metadata.versionsWithTypings
@@ -151,17 +150,10 @@ private inline fun <reified T> Yaml.decodeFromStringOrDefaultIfEmpty(
     default: T,
 ): T =
     if (text.isNotBlank()) {
-        protectedDecodeFromString(text)
+        decodeFromString(text)
     } else {
         default
     }
-
-private inline fun <reified T> Yaml.protectedDecodeFromString(text: String): T {
-    // protect against billion laughs attack until
-    // https://github.com/charleskorn/kaml/pull/620 is available
-    Load().loadOne(text)
-    return decodeFromString(text)
-}
 
 private fun String.versionToInt() = this.versionToIntOrNull() ?: error("Version '$this' cannot be treated as numeric!")
 
@@ -172,7 +164,7 @@ private val yaml =
         configuration =
             Yaml.default.configuration.copy(
                 strictMode = false,
-                anchorsAndAliases = AnchorsAndAliases.Permitted(10u),
+                anchorsAndAliases = AnchorsAndAliases.Permitted(),
             ),
     )
 

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
@@ -1,12 +1,12 @@
 package io.github.typesafegithub.workflows.actionbindinggenerator.typing
 
+import com.charleskorn.kaml.ForbiddenAnchorOrAliasException
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.CommitHash
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import it.krzeminski.snakeyaml.engine.kmp.exceptions.YamlEngineException
 import java.io.IOException
 import java.net.URI
 
@@ -535,10 +535,10 @@ class TypesProvidingTest :
 
                 // Expect
                 val exception =
-                    shouldThrow<YamlEngineException> {
+                    shouldThrow<ForbiddenAnchorOrAliasException> {
                         actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
                     }
-                exception.message shouldBe "Number of aliases for non-scalar nodes exceeds the specified max=50"
+                exception.message shouldBe "Maximum number of aliases has been reached."
             }
         }
 


### PR DESCRIPTION
kaml added proper support for configuring enablement of anchors and aliases. It's possible to remove the workaround of directly using snakeyaml-engine-kmp, and while here, depend on a sane default of 100 max aliases.