### PR TITLE
test(server): add test for using older Kotlin compiler

### DIFF
--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -119,12 +119,28 @@ workflow(
         )
     }
 
+    val testWithOlderKotlinAsConsumer = job(
+        id = "test-with-older-kotlin-as-consumer",
+        name = "Test with older Kotlin as consumer",
+        runsOn = UbuntuLatest,
+    ) {
+        val version = "1.8.0"
+        run(
+            name = "Download older Kotlin compiler",
+            command = "curl -o kotlin-compiler-$version.zip https://github.com/JetBrains/kotlin/releases/download/v$version/kotlin-compiler-$version.zip",
+        )
+        run(
+            name = "Unzip",
+            command = "unzip kotlin-compiler-$version.zip -d kotlin-compiler-$version",
+        )
+    }
+
     job(
         id = "deploy",
         name = "Deploy to DockerHub",
         runsOn = UbuntuLatest,
         `if` = expr { "${github.event_name} == 'workflow_dispatch' || ${github.event_name} == 'schedule'" },
-        needs = listOf(endToEndTest),
+        needs = listOf(endToEndTest, testWithOlderKotlinAsConsumer),
         env = mapOf(
             "DOCKERHUB_USERNAME" to expr { DOCKERHUB_USERNAME },
             "DOCKERHUB_PASSWORD" to expr { DOCKERHUB_PASSWORD },

--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -99,7 +99,9 @@ workflow(
             """.trimIndent(),
         )
 
-        val newestNotCompatibleVersion = "1.8.0"
+        // There should be a difference of one (mostly minor) version between these two,
+        // to be able to see the newest non-working and oldest working version.
+        val newestNotCompatibleVersion = "1.9.0"
         val oldestCompatibleVersion = "2.0.0"
 
         runWithSpecificKotlinVersion(

--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -99,30 +99,52 @@ workflow(
             """.trimIndent(),
         )
 
-        cleanMavenLocal()
-
         val newestNotCompatibleVersion = "1.8.0"
-        run(
-            name = "Download older Kotlin compiler",
-            command = "curl -Lo kotlin-compiler-$newestNotCompatibleVersion.zip https://github.com/JetBrains/kotlin/releases/download/v$newestNotCompatibleVersion/kotlin-compiler-$newestNotCompatibleVersion.zip",
-        )
-        run(
-            name = "Unzip and add to PATH",
-            command = "unzip kotlin-compiler-$newestNotCompatibleVersion.zip -d kotlin-compiler-$newestNotCompatibleVersion",
-        )
-        cleanMavenLocal()
-        // The below test depicts the current behavior that the served bindings aren't
-        // compatible with some older Kotlin version. We may want to address it one day.
-        // For more info, see https://github.com/typesafegithub/github-workflows-kt/issues/1756
-        run(
-            name = "Execute the script using the bindings from the server, using older Kotlin as consumer",
-            command = """
-                PATH=${'$'}(pwd)/kotlin-compiler-$newestNotCompatibleVersion/kotlinc/bin:${'$'}PATH
+        val oldestCompatibleVersion = "2.0.0"
+
+        newestNotCompatibleVersion.also { kotlinVersion ->
+            run(
+                name = "Download older Kotlin compiler ($kotlinVersion)",
+                command = "curl -Lo kotlin-compiler-$kotlinVersion.zip https://github.com/JetBrains/kotlin/releases/download/v$kotlinVersion/kotlin-compiler-$kotlinVersion.zip",
+            )
+            run(
+                name = "Unzip and add to PATH",
+                command = "unzip kotlin-compiler-$kotlinVersion.zip -d kotlin-compiler-$kotlinVersion",
+            )
+            cleanMavenLocal()
+            // The below test depicts the current behavior that the served bindings aren't
+            // compatible with some older Kotlin version. We may want to address it one day.
+            // For more info, see https://github.com/typesafegithub/github-workflows-kt/issues/1756
+            run(
+                name = "Execute the script using the bindings from the server, using older Kotlin ($kotlinVersion) as consumer",
+                command = """
+                PATH=${'$'}(pwd)/kotlin-compiler-$kotlinVersion/kotlinc/bin:${'$'}PATH
                 cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts
                 (.github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts || true) >> output.txt 2>&1
                 grep "was compiled with an incompatible version of Kotlin" output.txt
             """.trimIndent(),
-        )
+            )
+        }
+
+        oldestCompatibleVersion.also { kotlinVersion ->
+            run(
+                name = "Download older Kotlin compiler ($kotlinVersion)",
+                command = "curl -Lo kotlin-compiler-$kotlinVersion.zip https://github.com/JetBrains/kotlin/releases/download/v$kotlinVersion/kotlin-compiler-$kotlinVersion.zip",
+            )
+            run(
+                name = "Unzip and add to PATH",
+                command = "unzip kotlin-compiler-$kotlinVersion.zip -d kotlin-compiler-$kotlinVersion",
+            )
+            cleanMavenLocal()
+            run(
+                name = "Execute the script using the bindings from the server, using older Kotlin ($kotlinVersion) as consumer",
+                command = """
+                PATH=${'$'}(pwd)/kotlin-compiler-$kotlinVersion/kotlinc/bin:${'$'}PATH
+                cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-older-kotlin.main.kts
+                .github/workflows/test-script-consuming-jit-bindings-older-kotlin.main.kts
+            """.trimIndent(),
+            )
+        }
 
         run(
             name = "Compile a Gradle project using the bindings from the server",

--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -133,7 +133,7 @@ workflow(
             name = "Unzip and add to PATH",
             command = """
                 unzip kotlin-compiler-$version.zip -d kotlin-compiler-$version
-                PATH=${'$'}PATH:$(pwd)/kotlin-compiler-$version/kotlinc/bin
+                PATH=$(pwd)/kotlin-compiler-$version/kotlinc/bin:${'$'}PATH
             """.trimIndent(),
         )
         run(

--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -131,14 +131,14 @@ workflow(
         )
         run(
             name = "Unzip and add to PATH",
-            command = """
-                unzip kotlin-compiler-$version.zip -d kotlin-compiler-$version
-                PATH=$(pwd)/kotlin-compiler-$version/kotlinc/bin:${'$'}PATH
-            """.trimIndent(),
+            command = "unzip kotlin-compiler-$version.zip -d kotlin-compiler-$version",
         )
         run(
             name = "Smoke-test the compiler works fine",
-            command = "kotlinc -version",
+            command = """
+                PATH=${'$'}(pwd)/kotlin-compiler-$version/kotlinc/bin
+                kotlinc -version
+            """,
         )
     }
 

--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -136,7 +136,7 @@ workflow(
         run(
             name = "Smoke-test the compiler works fine",
             command = """
-                PATH=${'$'}(pwd)/kotlin-compiler-$version/kotlinc/bin
+                PATH=${'$'}(pwd)/kotlin-compiler-$version/kotlinc/bin:${'$'}PATH
                 kotlinc -version
             """,
         )

--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -127,11 +127,18 @@ workflow(
         val version = "1.8.0"
         run(
             name = "Download older Kotlin compiler",
-            command = "curl -o kotlin-compiler-$version.zip https://github.com/JetBrains/kotlin/releases/download/v$version/kotlin-compiler-$version.zip",
+            command = "curl -Lo kotlin-compiler-$version.zip https://github.com/JetBrains/kotlin/releases/download/v$version/kotlin-compiler-$version.zip",
         )
         run(
-            name = "Unzip",
-            command = "unzip kotlin-compiler-$version.zip -d kotlin-compiler-$version",
+            name = "Unzip and add to PATH",
+            command = """
+                unzip kotlin-compiler-$version.zip -d kotlin-compiler-$version
+                PATH=${'$'}PATH:$(pwd)/kotlin-compiler-$version/kotlinc/bin
+            """.trimIndent(),
+        )
+        run(
+            name = "Smoke-test the compiler works fine",
+            command = "kotlinc -version",
         )
     }
 

--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -124,7 +124,7 @@ workflow(
             name = "Execute the script using the bindings from the server, using older Kotlin as consumer",
             command = """
                 PATH=${'$'}(pwd)/kotlin-compiler-$version/kotlinc/bin:${'$'}PATH
-                mv .github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings-old-kotlin.main.kts
+                cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-old-kotlin.main.kts
                 .github/workflows/test-script-consuming-jit-bindings-old-kotlin.main.kts
             """.trimIndent(),
         )

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -71,26 +71,24 @@ jobs:
       name: 'Unzip and add to PATH'
       run: 'unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0'
     - id: 'step-11'
-      name: 'Smoke-test the compiler works fine'
-      run: "\n                PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH\n                kotlinc -version\n            "
-    - id: 'step-12'
       name: 'Clean Maven Local to fetch required POMs again'
       run: 'rm -rf ~/.m2/repository/'
-    - id: 'step-13'
+    - id: 'step-12'
       name: 'Execute the script using the bindings from the server, using older Kotlin as consumer'
       run: |-
         PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH
-        cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-old-kotlin.main.kts
-        .github/workflows/test-script-consuming-jit-bindings-old-kotlin.main.kts
-    - id: 'step-14'
+        cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts
+        (.github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts || true) >> output.txt 2>&1
+        grep "was compiled with an incompatible version of Kotlin" output.txt
+    - id: 'step-13'
       name: 'Compile a Gradle project using the bindings from the server'
       run: |-
         cd .github/workflows/test-gradle-project-using-bindings-server
         ./gradlew build
-    - id: 'step-15'
+    - id: 'step-14'
       name: 'Fetch maven-metadata.xml for top-level action'
       run: 'curl --fail http://localhost:8080/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-16'
+    - id: 'step-15'
       name: 'Fetch maven-metadata.xml for nested action'
       run: 'curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
   deploy:

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -88,7 +88,7 @@ jobs:
       name: 'Unzip and add to PATH'
       run: |-
         unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0
-        PATH=$PATH:$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin
+        PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH
     - id: 'step-2'
       name: 'Smoke-test the compiler works fine'
       run: 'kotlinc -version'

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -86,12 +86,10 @@ jobs:
       run: 'curl -Lo kotlin-compiler-1.8.0.zip https://github.com/JetBrains/kotlin/releases/download/v1.8.0/kotlin-compiler-1.8.0.zip'
     - id: 'step-1'
       name: 'Unzip and add to PATH'
-      run: |-
-        unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0
-        PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH
+      run: 'unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0'
     - id: 'step-2'
       name: 'Smoke-test the compiler works fine'
-      run: 'kotlinc -version'
+      run: "\n                PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin\n                kotlinc -version\n            "
   deploy:
     name: 'Deploy to DockerHub'
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -80,7 +80,7 @@ jobs:
       name: 'Execute the script using the bindings from the server, using older Kotlin as consumer'
       run: |-
         PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH
-        mv .github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings-old-kotlin.main.kts
+        cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-old-kotlin.main.kts
         .github/workflows/test-script-consuming-jit-bindings-old-kotlin.main.kts
     - id: 'step-14'
       name: 'Compile a Gradle project using the bindings from the server'

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -83,10 +83,15 @@ jobs:
     steps:
     - id: 'step-0'
       name: 'Download older Kotlin compiler'
-      run: 'curl -o kotlin-compiler-1.8.0.zip https://github.com/JetBrains/kotlin/releases/download/v1.8.0/kotlin-compiler-1.8.0.zip'
+      run: 'curl -Lo kotlin-compiler-1.8.0.zip https://github.com/JetBrains/kotlin/releases/download/v1.8.0/kotlin-compiler-1.8.0.zip'
     - id: 'step-1'
-      name: 'Unzip'
-      run: 'unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0'
+      name: 'Unzip and add to PATH'
+      run: |-
+        unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0
+        PATH=$PATH:$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin
+    - id: 'step-2'
+      name: 'Smoke-test the compiler works fine'
+      run: 'kotlinc -version'
   deploy:
     name: 'Deploy to DockerHub'
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -65,37 +65,39 @@ jobs:
       name: 'Clean Maven Local to fetch required POMs again'
       run: 'rm -rf ~/.m2/repository/'
     - id: 'step-9'
+      name: 'Download older Kotlin compiler'
+      run: 'curl -Lo kotlin-compiler-1.8.0.zip https://github.com/JetBrains/kotlin/releases/download/v1.8.0/kotlin-compiler-1.8.0.zip'
+    - id: 'step-10'
+      name: 'Unzip and add to PATH'
+      run: 'unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0'
+    - id: 'step-11'
+      name: 'Smoke-test the compiler works fine'
+      run: "\n                PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH\n                kotlinc -version\n            "
+    - id: 'step-12'
+      name: 'Clean Maven Local to fetch required POMs again'
+      run: 'rm -rf ~/.m2/repository/'
+    - id: 'step-13'
+      name: 'Execute the script using the bindings from the server, using older Kotlin as consumer'
+      run: |-
+        PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH
+        mv .github/workflows/test-script-consuming-jit-bindings.main.do-not-compile.kts .github/workflows/test-script-consuming-jit-bindings-old-kotlin.main.kts
+        .github/workflows/test-script-consuming-jit-bindings-old-kotlin.main.kts
+    - id: 'step-14'
       name: 'Compile a Gradle project using the bindings from the server'
       run: |-
         cd .github/workflows/test-gradle-project-using-bindings-server
         ./gradlew build
-    - id: 'step-10'
+    - id: 'step-15'
       name: 'Fetch maven-metadata.xml for top-level action'
       run: 'curl --fail http://localhost:8080/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-11'
+    - id: 'step-16'
       name: 'Fetch maven-metadata.xml for nested action'
       run: 'curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
-  test-with-older-kotlin-as-consumer:
-    name: 'Test with older Kotlin as consumer'
-    runs-on: 'ubuntu-latest'
-    needs:
-    - 'check_yaml_consistency'
-    steps:
-    - id: 'step-0'
-      name: 'Download older Kotlin compiler'
-      run: 'curl -Lo kotlin-compiler-1.8.0.zip https://github.com/JetBrains/kotlin/releases/download/v1.8.0/kotlin-compiler-1.8.0.zip'
-    - id: 'step-1'
-      name: 'Unzip and add to PATH'
-      run: 'unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0'
-    - id: 'step-2'
-      name: 'Smoke-test the compiler works fine'
-      run: "\n                PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH\n                kotlinc -version\n            "
   deploy:
     name: 'Deploy to DockerHub'
     runs-on: 'ubuntu-latest'
     needs:
     - 'end-to-end-test'
-    - 'test-with-older-kotlin-as-consumer'
     - 'check_yaml_consistency'
     env:
       DOCKERHUB_USERNAME: '${{ secrets.DOCKERHUB_USERNAME }}'

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -62,33 +62,45 @@ jobs:
         mv .github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts .github/workflows/test-served-bindings-depend-on-library.main.kts
         .github/workflows/test-served-bindings-depend-on-library.main.kts
     - id: 'step-8'
-      name: 'Clean Maven Local to fetch required POMs again'
-      run: 'rm -rf ~/.m2/repository/'
-    - id: 'step-9'
-      name: 'Download older Kotlin compiler'
+      name: 'Download older Kotlin compiler (1.8.0)'
       run: 'curl -Lo kotlin-compiler-1.8.0.zip https://github.com/JetBrains/kotlin/releases/download/v1.8.0/kotlin-compiler-1.8.0.zip'
-    - id: 'step-10'
+    - id: 'step-9'
       name: 'Unzip and add to PATH'
       run: 'unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0'
-    - id: 'step-11'
+    - id: 'step-10'
       name: 'Clean Maven Local to fetch required POMs again'
       run: 'rm -rf ~/.m2/repository/'
-    - id: 'step-12'
-      name: 'Execute the script using the bindings from the server, using older Kotlin as consumer'
+    - id: 'step-11'
+      name: 'Execute the script using the bindings from the server, using older Kotlin (1.8.0) as consumer'
       run: |-
         PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH
         cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts
         (.github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts || true) >> output.txt 2>&1
         grep "was compiled with an incompatible version of Kotlin" output.txt
+    - id: 'step-12'
+      name: 'Download older Kotlin compiler (2.0.0)'
+      run: 'curl -Lo kotlin-compiler-2.0.0.zip https://github.com/JetBrains/kotlin/releases/download/v2.0.0/kotlin-compiler-2.0.0.zip'
     - id: 'step-13'
+      name: 'Unzip and add to PATH'
+      run: 'unzip kotlin-compiler-2.0.0.zip -d kotlin-compiler-2.0.0'
+    - id: 'step-14'
+      name: 'Clean Maven Local to fetch required POMs again'
+      run: 'rm -rf ~/.m2/repository/'
+    - id: 'step-15'
+      name: 'Execute the script using the bindings from the server, using older Kotlin (2.0.0) as consumer'
+      run: |-
+        PATH=$(pwd)/kotlin-compiler-2.0.0/kotlinc/bin:$PATH
+        cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-older-kotlin.main.kts
+        .github/workflows/test-script-consuming-jit-bindings-older-kotlin.main.kts
+    - id: 'step-16'
       name: 'Compile a Gradle project using the bindings from the server'
       run: |-
         cd .github/workflows/test-gradle-project-using-bindings-server
         ./gradlew build
-    - id: 'step-14'
+    - id: 'step-17'
       name: 'Fetch maven-metadata.xml for top-level action'
       run: 'curl --fail http://localhost:8080/actions/checkout/maven-metadata.xml | grep ''<version>v4</version>'''
-    - id: 'step-15'
+    - id: 'step-18'
       name: 'Fetch maven-metadata.xml for nested action'
       run: 'curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
   deploy:

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -62,18 +62,18 @@ jobs:
         mv .github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts .github/workflows/test-served-bindings-depend-on-library.main.kts
         .github/workflows/test-served-bindings-depend-on-library.main.kts
     - id: 'step-8'
-      name: 'Download older Kotlin compiler (1.8.0)'
-      run: 'curl -Lo kotlin-compiler-1.8.0.zip https://github.com/JetBrains/kotlin/releases/download/v1.8.0/kotlin-compiler-1.8.0.zip'
+      name: 'Download older Kotlin compiler (1.9.0)'
+      run: 'curl -Lo kotlin-compiler-1.9.0.zip https://github.com/JetBrains/kotlin/releases/download/v1.9.0/kotlin-compiler-1.9.0.zip'
     - id: 'step-9'
       name: 'Unzip and add to PATH'
-      run: 'unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0'
+      run: 'unzip kotlin-compiler-1.9.0.zip -d kotlin-compiler-1.9.0'
     - id: 'step-10'
       name: 'Clean Maven Local to fetch required POMs again'
       run: 'rm -rf ~/.m2/repository/'
     - id: 'step-11'
-      name: 'Execute the script using the bindings from the server, using older Kotlin (1.8.0) as consumer'
+      name: 'Execute the script using the bindings from the server, using older Kotlin (1.9.0) as consumer'
       run: |2-
-                    PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH
+                    PATH=$(pwd)/kotlin-compiler-1.9.0/kotlinc/bin:$PATH
                                     cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts
                         (.github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts || true) >> output.txt 2>&1
         grep "was compiled with an incompatible version of Kotlin" output.txt

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -72,10 +72,10 @@ jobs:
       run: 'rm -rf ~/.m2/repository/'
     - id: 'step-11'
       name: 'Execute the script using the bindings from the server, using older Kotlin (1.8.0) as consumer'
-      run: |-
-        PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH
-        cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts
-        (.github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts || true) >> output.txt 2>&1
+      run: |2-
+                    PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH
+                                    cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts
+                        (.github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts || true) >> output.txt 2>&1
         grep "was compiled with an incompatible version of Kotlin" output.txt
     - id: 'step-12'
       name: 'Download older Kotlin compiler (2.0.0)'
@@ -88,9 +88,9 @@ jobs:
       run: 'rm -rf ~/.m2/repository/'
     - id: 'step-15'
       name: 'Execute the script using the bindings from the server, using older Kotlin (2.0.0) as consumer'
-      run: |-
-        PATH=$(pwd)/kotlin-compiler-2.0.0/kotlinc/bin:$PATH
-        cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-older-kotlin.main.kts
+      run: |2-
+                    PATH=$(pwd)/kotlin-compiler-2.0.0/kotlinc/bin:$PATH
+                    cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-older-kotlin.main.kts
         .github/workflows/test-script-consuming-jit-bindings-older-kotlin.main.kts
     - id: 'step-16'
       name: 'Compile a Gradle project using the bindings from the server'

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -89,7 +89,7 @@ jobs:
       run: 'unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0'
     - id: 'step-2'
       name: 'Smoke-test the compiler works fine'
-      run: "\n                PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin\n                kotlinc -version\n            "
+      run: "\n                PATH=$(pwd)/kotlin-compiler-1.8.0/kotlinc/bin:$PATH\n                kotlinc -version\n            "
   deploy:
     name: 'Deploy to DockerHub'
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -75,11 +75,24 @@ jobs:
     - id: 'step-11'
       name: 'Fetch maven-metadata.xml for nested action'
       run: 'curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
+  test-with-older-kotlin-as-consumer:
+    name: 'Test with older Kotlin as consumer'
+    runs-on: 'ubuntu-latest'
+    needs:
+    - 'check_yaml_consistency'
+    steps:
+    - id: 'step-0'
+      name: 'Download older Kotlin compiler'
+      run: 'curl -o kotlin-compiler-1.8.0.zip https://github.com/JetBrains/kotlin/releases/download/v1.8.0/kotlin-compiler-1.8.0.zip'
+    - id: 'step-1'
+      name: 'Unzip'
+      run: 'unzip kotlin-compiler-1.8.0.zip -d kotlin-compiler-1.8.0'
   deploy:
     name: 'Deploy to DockerHub'
     runs-on: 'ubuntu-latest'
     needs:
     - 'end-to-end-test'
+    - 'test-with-older-kotlin-as-consumer'
     - 'check_yaml_consistency'
     env:
       DOCKERHUB_USERNAME: '${{ secrets.DOCKERHUB_USERNAME }}'


### PR DESCRIPTION
Part of #1756.

The goal here is to both depict the current behavior, but also save us from unintentionally having Renovate auto-merge PRs that bump Kotlin version, which results in having incompatibility in Kotlin Metadata. The details of the problem are described in #1756.