### PR TITLE
fix: try removing library in binding POM

### DIFF
--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PomBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PomBuilding.kt
@@ -4,8 +4,6 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCo
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.fullName
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.prettyPrint
 
-internal const val LATEST_RELASED_LIBRARY_VERSION = "3.1.0"
-
 internal fun ActionCoords.buildPomFile() =
     """
     <?xml version="1.0" encoding="UTF-8"?>
@@ -22,13 +20,5 @@ internal fun ActionCoords.buildPomFile() =
         <developerConnection>scm:git:ssh://github.com:$owner/$name.git</developerConnection>
         <url>https://github.com/$owner/$name.git</url>
       </scm>
-      <dependencies>
-        <dependency>
-            <groupId>io.github.typesafegithub</groupId>
-            <artifactId>github-workflows-kt</artifactId>
-            <version>$LATEST_RELASED_LIBRARY_VERSION</version>
-            <scope>compile</scope>
-        </dependency>
-      </dependencies>
     </project>
     """.trimIndent()


### PR DESCRIPTION
This is problematic because it may make the users use older library than they want. Let's try removing it.