### PR TITLE
fix(server): return 'not found' for maven-metadata.xml if no major version found

### DIFF
--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuilding.kt
@@ -4,11 +4,11 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCo
 import io.github.typesafegithub.workflows.shared.internal.fetchAvailableVersions
 import java.time.format.DateTimeFormatter
 
-internal suspend fun ActionCoords.buildMavenMetadataFile(githubToken: String): String {
+internal suspend fun ActionCoords.buildMavenMetadataFile(githubToken: String): String? {
     val availableMajorVersions =
         fetchAvailableVersions(owner = owner, name = name, githubToken = githubToken)
             .filter { it.isMajorVersion() }
-    val newest = availableMajorVersions.max()
+    val newest = availableMajorVersions.maxOrNull() ?: return null
     val lastUpdated =
         DateTimeFormatter
             .ofPattern("yyyyMMddHHmmss")

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PackageArtifactsBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PackageArtifactsBuilding.kt
@@ -3,7 +3,7 @@ package io.github.typesafegithub.workflows.mavenbinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 
 suspend fun ActionCoords.buildPackageArtifacts(githubToken: String): Map<String, String> {
-    val mavenMetadata = buildMavenMetadataFile(githubToken = githubToken)
+    val mavenMetadata = buildMavenMetadataFile(githubToken = githubToken) ?: return emptyMap()
     return mapOf(
         "maven-metadata.xml" to mavenMetadata,
         "maven-metadata.xml.md5" to mavenMetadata.md5Checksum(),


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/1774.

It doesn't fix the entire issue because we should be able to see the major versions, even if they don't have the `v` in front, because such versions are consumable as action bindings. This change just prevents the failures of the server.