### PR TITLE
refactor(library): move building step outputs to ActionStep

### DIFF
--- a/github-workflows-kt/api/github-workflows-kt.api
+++ b/github-workflows-kt/api/github-workflows-kt.api
@@ -19,8 +19,8 @@ public final class io/github/typesafegithub/workflows/domain/AbstractResult$Stat
 }
 
 public class io/github/typesafegithub/workflows/domain/ActionStep : io/github/typesafegithub/workflows/domain/Step {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/typesafegithub/workflows/domain/actions/Action;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/github/typesafegithub/workflows/domain/actions/Action$Outputs;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/typesafegithub/workflows/domain/actions/Action;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/github/typesafegithub/workflows/domain/actions/Action$Outputs;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/typesafegithub/workflows/domain/actions/Action;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/typesafegithub/workflows/domain/actions/Action;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getAction ()Lio/github/typesafegithub/workflows/domain/actions/Action;
 	public fun getCondition ()Ljava/lang/String;
 	public fun getContinueOnError ()Ljava/lang/Boolean;

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/Step.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/Step.kt
@@ -76,7 +76,6 @@ public open class ActionStep<out OUTPUTS : Outputs>(
     override val condition: String? = null,
     override val continueOnError: Boolean? = null,
     override val timeoutMinutes: Int? = null,
-    override val outputs: OUTPUTS,
     override val _customArguments: Map<String, @Contextual Any?> = emptyMap(),
 ) : Step<OUTPUTS>(
         id = id,
@@ -84,6 +83,9 @@ public open class ActionStep<out OUTPUTS : Outputs>(
         continueOnError = continueOnError,
         timeoutMinutes = timeoutMinutes,
         env = env,
-        outputs = outputs,
+        outputs = action.buildOutputObject(id),
         _customArguments = _customArguments,
-    )
+    ) {
+    override val outputs: OUTPUTS
+        get() = super.outputs
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/dsl/JobBuilder.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/dsl/JobBuilder.kt
@@ -194,7 +194,6 @@ public class JobBuilder<OUTPUT : JobOutputs>(
                 condition = `if` ?: condition,
                 continueOnError = continueOnError,
                 timeoutMinutes = timeoutMinutes,
-                outputs = action.buildOutputObject(stepId),
                 _customArguments = _customArguments,
             )
         job = job.copy(steps = job.steps + newStep)

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/StepTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/StepTest.kt
@@ -2,7 +2,6 @@ package io.github.typesafegithub.workflows.domain
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.domain.AbstractResult.Status
-import io.github.typesafegithub.workflows.domain.actions.Action
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -21,7 +20,6 @@ class StepTest :
                 ActionStep(
                     id = "whatever",
                     action = Checkout(),
-                    outputs = Action.Outputs("whatever"),
                 )
             someStep.conclusion.toString() shouldBe "steps.whatever.conclusion"
             someStep.conclusion eq Status.Failure shouldBe "steps.whatever.conclusion == 'failure'"

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/yaml/StepsToYamlTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/yaml/StepsToYamlTest.kt
@@ -8,7 +8,6 @@ import io.github.typesafegithub.workflows.actions.actions.UploadArtifact
 import io.github.typesafegithub.workflows.domain.ActionStep
 import io.github.typesafegithub.workflows.domain.CommandStep
 import io.github.typesafegithub.workflows.domain.Shell
-import io.github.typesafegithub.workflows.domain.actions.Action
 import io.github.typesafegithub.workflows.domain.actions.CustomAction
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -28,7 +27,6 @@ class StepsToYamlTest :
                         id = "someId",
                         name = "Some external action",
                         action = Checkout(),
-                        outputs = Action.Outputs("someId"),
                     ),
                 )
 
@@ -239,7 +237,6 @@ class StepsToYamlTest :
                         ActionStep(
                             id = "someId",
                             action = Checkout(),
-                            outputs = Action.Outputs("someId"),
                         ),
                     )
 
@@ -276,7 +273,6 @@ class StepsToYamlTest :
                                         """.trimIndent(),
                                 ),
                             condition = "\${{ matrix.foo == 'bar' }}",
-                            outputs = Action.Outputs("someId"),
                             _customArguments =
                                 mapOf(
                                     "foo" to true,
@@ -339,7 +335,6 @@ class StepsToYamlTest :
                                             "compiler" to "latexmk",
                                         ),
                                 ),
-                            outputs = Action.Outputs("someId"),
                         ),
                     )
 
@@ -378,7 +373,6 @@ class StepsToYamlTest :
                                             "answer" to "42",
                                         ),
                                 ),
-                            outputs = Action.Outputs("someId"),
                         ),
                     )
 
@@ -413,7 +407,6 @@ class StepsToYamlTest :
                                     path = listOf("path1", "path2"),
                                     _customVersion = "v2.3.4",
                                 ),
-                            outputs = Action.Outputs("someId"),
                         ),
                     )
 
@@ -447,7 +440,6 @@ class StepsToYamlTest :
                             id = "someId",
                             name = "Will be overridden",
                             action = Checkout(),
-                            outputs = Action.Outputs("someId"),
                             _customArguments =
                                 mapOf(
                                     "name" to "Overridden!",


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/1780.

It will help us provide cleaner API for describing a step outside of the `job` DSL function.