### PR TITLE
feat(library): add 'number' as input type of WorkflowDispatch

### DIFF
--- a/github-workflows-kt/api/github-workflows-kt.api
+++ b/github-workflows-kt/api/github-workflows-kt.api
@@ -1863,6 +1863,7 @@ public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowDi
 	public static final field Choice Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type$Companion;
 	public static final field Environment Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
+	public static final field Number Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
 	public static final field String Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch.kt
@@ -21,6 +21,9 @@ public data class WorkflowDispatch(
         @SerialName("boolean")
         Boolean,
 
+        @SerialName("number")
+        Number,
+
         @SerialName("string")
         String,
     }

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/yaml/TriggersToYamlTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/yaml/TriggersToYamlTest.kt
@@ -68,6 +68,12 @@ class TriggersToYamlTest :
                                             type = WorkflowDispatch.Type.Boolean,
                                             required = false,
                                         ),
+                                    "retries" to
+                                        WorkflowDispatch.Input(
+                                            description = "Number of retries",
+                                            type = WorkflowDispatch.Type.Number,
+                                            required = false,
+                                        ),
                                     "environment" to
                                         WorkflowDispatch.Input(
                                             description = "Environment to run tests against",
@@ -106,6 +112,12 @@ class TriggersToYamlTest :
                                             mapOf(
                                                 "description" to "Test scenario tags",
                                                 "type" to "boolean",
+                                                "required" to false,
+                                            ),
+                                        "retries" to
+                                            mapOf(
+                                                "description" to "Number of retries",
+                                                "type" to "number",
                                                 "required" to false,
                                             ),
                                         "environment" to


### PR DESCRIPTION
Technically a breaking change for anyone that relies on enum's exhaustiveness, but I think such usage is highly unlikely.