### PR TITLE
feat(server): allow empty inputs and outputs in typings

### DIFF
--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/ActionTypes.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/ActionTypes.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class ActionTypes(
-    val inputs: Map<String, ActionType> = emptyMap(),
-    val outputs: Map<String, ActionType> = emptyMap(),
+    val inputs: Map<String, ActionType>? = null,
+    val outputs: Map<String, ActionType>? = null,
 )
 
 @Serializable

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
@@ -113,9 +113,9 @@ private fun fetchTypingsFromUrl(
 }
 
 internal fun ActionTypes.toTypesMap(): Map<String, Typing> =
-    inputs.mapValues { (key, value) ->
+    inputs?.mapValues { (key, value) ->
         value.toTyping(key)
-    }
+    } ?: emptyMap()
 
 private fun ActionCoords.toMajorVersion(): ActionCoords = this.copy(version = this.version.substringBefore("."))
 

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
@@ -36,6 +36,46 @@ class TypesProvidingTest :
             types.first shouldBe emptyMap()
         }
 
+        test("copes with empty inputs") {
+            // Given
+            val actionTypesYml = "inputs:"
+            val actionCoord = ActionCoords("some-owner", "some-name", "v1")
+
+            // When
+            val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
+
+            // Then
+            types.first shouldBe emptyMap()
+        }
+
+        test("copes with empty outputs") {
+            // Given
+            val actionTypesYml = "outputs:"
+            val actionCoord = ActionCoords("some-owner", "some-name", "v1")
+
+            // When
+            val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
+
+            // Then
+            types.first shouldBe emptyMap()
+        }
+
+        test("copes with empty inputs and outputs") {
+            // Given
+            val actionTypesYml =
+                """
+                inputs:
+                outputs:
+                """.trimIndent()
+            val actionCoord = ActionCoords("some-owner", "some-name", "v1")
+
+            // When
+            val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
+
+            // Then
+            types.first shouldBe emptyMap()
+        }
+
         test("parses all allowed elements of valid typing") {
             // Given
             val actionTypesYml =


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-actions-typing/issues/253.
A similar change was done in https://github.com/typesafegithub/github-actions-typing/pull/265.