### PR TITLE
chore(server): remove unnecessary else branch on ArtifactRoutes

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutes.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutes.kt
@@ -84,7 +84,6 @@ private fun Route.getArtifact(
         when (artifact) {
             is TextArtifact -> call.respondText(artifact.data())
             is JarArtifact -> call.respondBytes(artifact.data(), ContentType.parse("application/java-archive"))
-            else -> call.respondNotFound()
         }
     }
 }


### PR DESCRIPTION
The when expression is now exhaustive and the compiler can imply that the else branch is never reached.

This commit removed the useless else branch without changing any functionality.