### PR TITLE
feat(server): replace cache library with Aedile

### DIFF
--- a/jit-binding-server/build.gradle.kts
+++ b/jit-binding-server/build.gradle.kts
@@ -18,8 +18,8 @@ dependencies {
     implementation("io.ktor:ktor-server-call-id")
     implementation("io.ktor:ktor-server-metrics-micrometer")
     implementation("io.micrometer:micrometer-registry-prometheus:1.14.4")
-    
-    implementation("io.github.reactivecircus.cache4k:cache4k:0.14.0")
+
+    implementation("com.sksamuel.aedile:aedile-core:2.0.3")
     implementation("io.github.oshai:kotlin-logging:7.0.4")
     implementation(platform("org.apache.logging.log4j:log4j-bom:2.24.3"))
     implementation("org.apache.logging.log4j:log4j-jul")


### PR DESCRIPTION
In order to have a better monitoring of our cache, a library that easily
 exposes metrics is a requirement.

This commit replaces the current cache implementation with Aedile, a wrapper to Caffeine.

Caffeine supports monitoring natively, while aedile allows us to access it without losing the kotlin-like style.