### PR TITLE
fix: display full response and don't fail if GitHub responds with non-success

### DIFF
--- a/action-updates-checker/src/main/kotlin/io/github/typesafegithub/workflows/updates/Utils.kt
+++ b/action-updates-checker/src/main/kotlin/io/github/typesafegithub/workflows/updates/Utils.kt
@@ -1,5 +1,6 @@
 package io.github.typesafegithub.workflows.updates
 
+import arrow.core.getOrElse
 import io.github.typesafegithub.workflows.domain.ActionStep
 import io.github.typesafegithub.workflows.domain.Workflow
 import io.github.typesafegithub.workflows.domain.actions.RegularAction
@@ -54,7 +55,10 @@ internal suspend fun RegularAction<*>.fetchAvailableVersionsOrWarn(githubToken: 
             owner = actionOwner,
             name = actionName.substringBefore('/'),
             githubToken = githubToken,
-        )
+        ).getOrElse {
+            println(it)
+            emptyList()
+        }
     } catch (e: Exception) {
         githubError(
             "failed to fetch versions for $actionOwner/$actionName, skipping",

--- a/action-updates-checker/src/main/kotlin/io/github/typesafegithub/workflows/updates/Utils.kt
+++ b/action-updates-checker/src/main/kotlin/io/github/typesafegithub/workflows/updates/Utils.kt
@@ -55,9 +55,8 @@ internal suspend fun RegularAction<*>.fetchAvailableVersionsOrWarn(githubToken: 
             owner = actionOwner,
             name = actionName.substringBefore('/'),
             githubToken = githubToken,
-        ).getOrElse {
-            println(it)
-            emptyList()
+        ) .getOrElse {
+            throw Exception(it)
         }
     } catch (e: Exception) {
         githubError(

--- a/action-updates-checker/src/main/kotlin/io/github/typesafegithub/workflows/updates/Utils.kt
+++ b/action-updates-checker/src/main/kotlin/io/github/typesafegithub/workflows/updates/Utils.kt
@@ -55,7 +55,7 @@ internal suspend fun RegularAction<*>.fetchAvailableVersionsOrWarn(githubToken: 
             owner = actionOwner,
             name = actionName.substringBefore('/'),
             githubToken = githubToken,
-        ) .getOrElse {
+        ).getOrElse {
             throw Exception(it)
         }
     } catch (e: Exception) {

--- a/maven-binding-builder/build.gradle.kts
+++ b/maven-binding-builder/build.gradle.kts
@@ -4,8 +4,10 @@ plugins {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-compiler")
+    api("io.arrow-kt:arrow-core:2.0.1")
     api(projects.actionBindingGenerator)
     implementation(projects.sharedInternal)
+    implementation("io.github.oshai:kotlin-logging:7.0.5")
 
     runtimeOnly(projects.githubWorkflowsKt)
 }

--- a/maven-binding-builder/src/test/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuildingTest.kt
+++ b/maven-binding-builder/src/test/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuildingTest.kt
@@ -1,5 +1,7 @@
 package io.github.typesafegithub.workflows.mavenbinding
 
+import arrow.core.Either
+import arrow.core.right
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion.FULL
@@ -20,7 +22,7 @@ class MavenMetadataBuildingTest :
 
         test("various kinds of versions available") {
             // Given
-            val fetchAvailableVersions: suspend (String, String, String?) -> List<Version> = { _, _, _ ->
+            val fetchAvailableVersions: suspend (String, String, String?) -> Either<String, List<Version>> = { _, _, _ ->
                 listOf(
                     Version(version = "v3-beta", dateProvider = { ZonedDateTime.parse("2024-07-01T00:00:00Z") }),
                     Version(version = "v2", dateProvider = { ZonedDateTime.parse("2024-05-01T00:00:00Z") }),
@@ -30,7 +32,7 @@ class MavenMetadataBuildingTest :
                     Version(version = "v1.0.1", dateProvider = { ZonedDateTime.parse("2024-03-05T00:00:00Z") }),
                     Version(version = "v1.0", dateProvider = { ZonedDateTime.parse("2024-03-01T00:00:00Z") }),
                     Version(version = "v1.0.0", dateProvider = { ZonedDateTime.parse("2024-03-01T00:00:00Z") }),
-                )
+                ).right()
             }
 
             val xml =
@@ -60,14 +62,14 @@ class MavenMetadataBuildingTest :
 
         test("no major versions") {
             // Given
-            val fetchAvailableVersions: suspend (String, String, String?) -> List<Version> = { _, _, _ ->
+            val fetchAvailableVersions: suspend (String, String, String?) -> Either<String, List<Version>> = { _, _, _ ->
                 listOf(
                     Version(version = "v1.1", dateProvider = { ZonedDateTime.parse("2024-03-07T00:00:00Z") }),
                     Version(version = "v1.1.0", dateProvider = { ZonedDateTime.parse("2024-03-07T00:00:00Z") }),
                     Version(version = "v1.0.1", dateProvider = { ZonedDateTime.parse("2024-03-05T00:00:00Z") }),
                     Version(version = "v1.0", dateProvider = { ZonedDateTime.parse("2024-03-01T00:00:00Z") }),
                     Version(version = "v1.0.0", dateProvider = { ZonedDateTime.parse("2024-03-01T00:00:00Z") }),
-                )
+                ).right()
             }
 
             val xml =
@@ -81,8 +83,8 @@ class MavenMetadataBuildingTest :
 
         test("no versions available") {
             // Given
-            val fetchAvailableVersions: suspend (String, String, String?) -> List<Version> = { _, _, _ ->
-                emptyList()
+            val fetchAvailableVersions: suspend (String, String, String?) -> Either<String, List<Version>> = { _, _, _ ->
+                emptyList<Version>().right()
             }
 
             val xml =
@@ -97,7 +99,7 @@ class MavenMetadataBuildingTest :
         (SignificantVersion.entries - FULL).forEach { significantVersion ->
             test("significant version $significantVersion requested") {
                 // Given
-                val fetchAvailableVersions: suspend (String, String, String?) -> List<Version> = { owner, name, _ ->
+                val fetchAvailableVersions: suspend (String, String, String?) -> Either<String, List<Version>> = { owner, name, _ ->
                     listOf(
                         Version(version = "v3-beta", dateProvider = { ZonedDateTime.parse("2024-07-01T00:00:00Z") }),
                         Version(version = "v2", dateProvider = { ZonedDateTime.parse("2024-05-01T00:00:00Z") }),
@@ -107,7 +109,7 @@ class MavenMetadataBuildingTest :
                         Version(version = "v1.0.1", dateProvider = { ZonedDateTime.parse("2024-03-05T00:00:00Z") }),
                         Version(version = "v1.0", dateProvider = { ZonedDateTime.parse("2024-03-01T00:00:00Z") }),
                         Version(version = "v1.0.0", dateProvider = { ZonedDateTime.parse("2024-03-01T00:00:00Z") }),
-                    )
+                    ).right()
                 }
 
                 val xml =

--- a/shared-internal/build.gradle.kts
+++ b/shared-internal/build.gradle.kts
@@ -9,6 +9,7 @@ group = rootProject.group
 version = rootProject.version
 
 dependencies {
+    api("io.arrow-kt:arrow-core:2.0.1")
     // we cannot use a BOM due to limitation in kotlin scripting when resolving the transitive KMM variant dependencies
     // note: see https://youtrack.jetbrains.com/issue/KT-67618
     api("io.ktor:ktor-client-core:3.1.1")

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubApi.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubApi.kt
@@ -1,5 +1,8 @@
 package io.github.typesafegithub.workflows.shared.internal
 
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.ensure
 import io.github.typesafegithub.workflows.shared.internal.model.Version
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -8,6 +11,7 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
+import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -18,36 +22,39 @@ suspend fun fetchAvailableVersions(
     name: String,
     githubToken: String?,
     httpClientEngine: HttpClientEngine = CIO.create(),
-): List<Version> {
-    val httpClient = buildHttpClient(engine = httpClientEngine)
-    return listOf(
-        apiTagsUrl(owner = owner, name = name),
-        apiBranchesUrl(owner = owner, name = name),
-    ).flatMap { url -> fetchGithubRefs(url, githubToken, httpClient) }
-        .versions(githubToken, httpClient)
-}
+): Either<String, List<Version>> =
+    either {
+        val httpClient = buildHttpClient(engine = httpClientEngine)
+        return listOf(
+            apiTagsUrl(owner = owner, name = name),
+            apiBranchesUrl(owner = owner, name = name),
+        ).flatMap { url -> fetchGithubRefs(url, githubToken, httpClient).bind() }
+            .versions(githubToken, httpClient)
+    }
 
 private fun List<GithubRef>.versions(
     githubToken: String?,
     httpClient: HttpClient,
-): List<Version> =
-    this.map { githubRef ->
-        val version = githubRef.ref.substringAfterLast("/")
-        Version(version) {
-            val response =
-                httpClient
-                    .get(urlString = githubRef.`object`.url) {
-                        if (githubToken != null) {
-                            bearerAuth(githubToken)
+): Either<String, List<Version>> =
+    either {
+        this@versions.map { githubRef ->
+            val version = githubRef.ref.substringAfterLast("/")
+            Version(version) {
+                val response =
+                    httpClient
+                        .get(urlString = githubRef.`object`.url) {
+                            if (githubToken != null) {
+                                bearerAuth(githubToken)
+                            }
                         }
-                    }
-            val releaseDate =
-                when (githubRef.`object`.type) {
-                    "tag" -> response.body<Tag>().tagger
-                    "commit" -> response.body<Commit>().author
-                    else -> error("Unexpected target object type ${githubRef.`object`.type}")
-                }.date
-            ZonedDateTime.parse(releaseDate)
+                val releaseDate =
+                    when (githubRef.`object`.type) {
+                        "tag" -> response.body<Tag>().tagger
+                        "commit" -> response.body<Commit>().author
+                        else -> error("Unexpected target object type ${githubRef.`object`.type}")
+                    }.date
+                ZonedDateTime.parse(releaseDate)
+            }
         }
     }
 
@@ -55,13 +62,20 @@ private suspend fun fetchGithubRefs(
     url: String,
     githubToken: String?,
     httpClient: HttpClient,
-): List<GithubRef> =
-    httpClient
-        .get(urlString = url) {
-            if (githubToken != null) {
-                bearerAuth(githubToken)
-            }
-        }.body()
+): Either<String, List<GithubRef>> =
+    either {
+        val response =
+            httpClient
+                .get(urlString = url) {
+                    if (githubToken != null) {
+                        bearerAuth(githubToken)
+                    }
+                }
+        ensure(response.status.isSuccess()) {
+            "Unexpected response when fetching refs from $url. Status: ${response.status}, response: {\"message\":  \"There was a problem!\"}"
+        }
+        response.body()
+    }
 
 private fun apiTagsUrl(
     owner: String,

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubApi.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubApi.kt
@@ -11,6 +11,7 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.Serializable
@@ -72,7 +73,7 @@ private suspend fun fetchGithubRefs(
                     }
                 }
         ensure(response.status.isSuccess()) {
-            "Unexpected response when fetching refs from $url. Status: ${response.status}, response: {\"message\":  \"There was a problem!\"}"
+            "Unexpected response when fetching refs from $url. Status: ${response.status}, response: ${response.bodyAsText()}"
         }
         response.body()
     }


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/1855.

This PR also adds graceful handling of non-success responses from GitHub: instead of exceptions we started using Arrow Kt and `Either`.