### PR TITLE
chore: migrate to Dokka plugin V2

### DIFF
--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -80,7 +80,7 @@ private fun JobBuilder<*>.deployDocs() {
     uses(action = ActionsSetupGradle())
     run(
         name = "Generate API docs",
-        command = "./gradlew :github-workflows-kt:dokkaGeneratePublicationHtml --no-configuration-cache",
+        command = "./gradlew :github-workflows-kt:dokkaGenerate --no-configuration-cache",
     )
     run(
         name = "Prepare target directory for API docs",

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -80,7 +80,7 @@ private fun JobBuilder<*>.deployDocs() {
     uses(action = ActionsSetupGradle())
     run(
         name = "Generate API docs",
-        command = "./gradlew :github-workflows-kt:dokkaGenerate --no-configuration-cache",
+        command = "./gradlew :github-workflows-kt:dokkaGenerate",
     )
     run(
         name = "Prepare target directory for API docs",

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -80,7 +80,7 @@ private fun JobBuilder<*>.deployDocs() {
     uses(action = ActionsSetupGradle())
     run(
         name = "Generate API docs",
-        command = "./gradlew :github-workflows-kt:dokkaHtml --no-configuration-cache",
+        command = "./gradlew :github-workflows-kt:dokkaGeneratePublicationHtml --no-configuration-cache",
     )
     run(
         name = "Prepare target directory for API docs",

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,7 +98,7 @@ jobs:
       uses: 'gradle/actions/setup-gradle@v4'
     - id: 'step-16'
       name: 'Generate API docs'
-      run: './gradlew :github-workflows-kt:dokkaGeneratePublicationHtml --no-configuration-cache'
+      run: './gradlew :github-workflows-kt:dokkaGenerate --no-configuration-cache'
     - id: 'step-17'
       name: 'Prepare target directory for API docs'
       run: 'mkdir -p to-gh-pages/api-docs'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,7 +98,7 @@ jobs:
       uses: 'gradle/actions/setup-gradle@v4'
     - id: 'step-16'
       name: 'Generate API docs'
-      run: './gradlew :github-workflows-kt:dokkaHtml --no-configuration-cache'
+      run: './gradlew :github-workflows-kt:dokkaGeneratePublicationHtml --no-configuration-cache'
     - id: 'step-17'
       name: 'Prepare target directory for API docs'
       run: 'mkdir -p to-gh-pages/api-docs'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,7 +98,7 @@ jobs:
       uses: 'gradle/actions/setup-gradle@v4'
     - id: 'step-16'
       name: 'Generate API docs'
-      run: './gradlew :github-workflows-kt:dokkaGenerate --no-configuration-cache'
+      run: './gradlew :github-workflows-kt:dokkaGenerate'
     - id: 'step-17'
       name: 'Prepare target directory for API docs'
       run: 'mkdir -p to-gh-pages/api-docs'

--- a/github-workflows-kt/build.gradle.kts
+++ b/github-workflows-kt/build.gradle.kts
@@ -77,6 +77,6 @@ pitest {
     junit5PluginVersion.set("1.1.0")
 }
 
-tasks.dokkaHtml {
+dokka {
     moduleName.set("github-workflows-kt")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,5 @@ kotlin.incremental.useClasspathSnapshot=true
 
 # So that KSP doesn't generate files in "test" sources root
 ksp.allow.all.target.configuration=false
+
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
In Dokka 2.1.0, the V1 mode will be gone. Opting in proactively, and to get rid of annoying warnings.