### PR TITLE
chore(server): use magenta for trace log lines

### DIFF
--- a/jit-binding-server/src/main/resources/log4j2.xml
+++ b/jit-binding-server/src/main/resources/log4j2.xml
@@ -4,7 +4,7 @@
     <Appenders>
         <Console name="Console Appender">
             <PatternLayout>
-                <Pattern><![CDATA[%highlight{%d <%-5p> <%-35.35t> <%x> <%X> <%50.50c> %m}%n]]></Pattern>
+                <Pattern><![CDATA[%highlight{%d <%-5p> <%-35.35t> <%x> <%X> <%50.50c> %m}{TRACE = magenta}%n]]></Pattern>
             </PatternLayout>
         </Console>
     </Appenders>


### PR DESCRIPTION
Trace lines by default are printed black which on a dark background is nearly unreadable unless you select the lines.
With this change we print them magenta instead which is readable on dark and light backgrounds properly