### PR TITLE
chore(ci): remove triggering server image pull

### DIFF
--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -30,7 +30,6 @@ import kotlin.time.TimeSource
 
 val DOCKERHUB_USERNAME by Contexts.secrets
 val DOCKERHUB_PASSWORD by Contexts.secrets
-val TRIGGER_IMAGE_PULL by Contexts.secrets
 val APP_PRIVATE_KEY by Contexts.secrets
 
 @OptIn(ExperimentalKotlinLogicStep::class)
@@ -166,10 +165,6 @@ workflow(
         run(
             name = "Build and publish image",
             command = "./gradlew :jit-binding-server:publishImage",
-        )
-        run(
-            name = "Use newest image on the server",
-            command = "curl -X POST ${expr { TRIGGER_IMAGE_PULL }} --insecure",
         )
     }
 }

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -136,6 +136,3 @@ jobs:
     - id: 'step-2'
       name: 'Build and publish image'
       run: './gradlew :jit-binding-server:publishImage'
-    - id: 'step-3'
-      name: 'Use newest image on the server'
-      run: 'curl -X POST ${{ secrets.TRIGGER_IMAGE_PULL }} --insecure'


### PR DESCRIPTION
Per https://kotlinlang.slack.com/archives/C02UUATR7RC/p1743596200759679?thread_ts=1742907721.287939&cid=C02UUATR7RC:

> Watchtower enabled for our container only. Let's see how it goes.
> Updates should happen as soon as the docker image is created in
> dockerhub and the webhook is no longer necessary (probably worked
> only as a placebo anyways)

We can remove this webhook calling (that doesn't work anyway) and rely on periodic image pulls by Watchtower.