### PR TITLE
feat(server): allow configuring client ID and installation ID vial env vars

### DIFF
--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -53,6 +53,8 @@ workflow(
         runsOn = UbuntuLatest,
         env = mapOf(
             "APP_PRIVATE_KEY" to expr { APP_PRIVATE_KEY },
+            "APP_INSTALLATION_ID" to "62885502",
+            "APP_CLIENT_ID" to "Iv23liIZ17VJKUpjacBs",
         ),
     ) {
         uses(action = Checkout())

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -49,6 +49,8 @@ jobs:
     - 'check_yaml_consistency'
     env:
       APP_PRIVATE_KEY: '${{ secrets.APP_PRIVATE_KEY }}'
+      APP_INSTALLATION_ID: '62885502'
+      APP_CLIENT_ID: 'Iv23liIZ17VJKUpjacBs'
     steps:
     - id: 'step-0'
       uses: 'actions/checkout@v4'


### PR DESCRIPTION
Thanks to this, it's easier to test with different client ID and installation ID - no code changes are required.
Per @Vampire's request: https://kotlinlang.slack.com/archives/C02UUATR7RC/p1743494744804909?thread_ts=1742907721.287939&cid=C02UUATR7RC