### PR TITLE
feat(server): add fallback to GITHUB_TOKEN if installation token fails

### DIFF
--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
@@ -1,6 +1,9 @@
 package io.github.typesafegithub.workflows.shared.internal
 
+import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import kotlinx.coroutines.runBlocking
+
+private val logger = logger { }
 
 /**
  * Returns a token that should be used to make authorized calls to GitHub,
@@ -10,12 +13,9 @@ import kotlinx.coroutines.runBlocking
  */
 fun getGithubAuthTokenOrNull(): String? =
     runBlocking {
-        (System.getenv("GITHUB_TOKEN") ?: getInstallationAccessToken())
-            .also {
-                if (it == null) {
-                    println(ERROR_NO_CONFIGURATION)
-                }
-            }
+        runCatching { getInstallationAccessToken() }
+            .onFailure { logger.warn(it) { "Failed to get GitHub App Installation token, falling back to GITHUB_TOKEN." } }
+            .getOrNull() ?: System.getenv("GITHUB_TOKEN")
     }
 
 /**

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
@@ -16,7 +16,7 @@ fun getGithubAuthTokenOrNull(): String? =
         runCatching { getInstallationAccessToken() }
             .onFailure { logger.warn(it) { "Failed to get GitHub App Installation token, falling back to GITHUB_TOKEN." } }
             .getOrNull() ?: System.getenv("GITHUB_TOKEN")
-    }
+    }.also { if (it == null) logger.warn { ERROR_NO_CONFIGURATION } }
 
 /**
  * Returns a token that should be used to make authorized calls to GitHub,


### PR DESCRIPTION
- Attempts to retrieve a GitHub App Installation token first
- Falls back to GITHUB_TOKEN if the installation token fails
- Logs a warning on failure of installation token retrieval
- Updated KDocs for both getGithubAuthToken and getGithubAuthTokenOrNull