### PR TITLE
chore: return token type for github auth token

### DIFF
--- a/action-updates-checker/src/main/kotlin/io/github/typesafegithub/workflows/updates/Reporting.kt
+++ b/action-updates-checker/src/main/kotlin/io/github/typesafegithub/workflows/updates/Reporting.kt
@@ -39,7 +39,7 @@ internal suspend fun Workflow.reportAvailableUpdatesInternal(
 ) {
     availableVersionsForEachAction(
         reportWhenTokenUnset = reportWhenTokenUnset,
-        githubAuthToken = githubAuthToken ?: getGithubAuthTokenOrNull(),
+        githubAuthToken = githubAuthToken ?: getGithubAuthTokenOrNull()?.first,
     ).onEach { regularActionVersions ->
         val usesString =
             with(regularActionVersions.action) {

--- a/action-updates-checker/src/main/kotlin/io/github/typesafegithub/workflows/updates/Utils.kt
+++ b/action-updates-checker/src/main/kotlin/io/github/typesafegithub/workflows/updates/Utils.kt
@@ -17,7 +17,7 @@ import kotlin.io.path.readText
 
 internal suspend fun Workflow.availableVersionsForEachAction(
     reportWhenTokenUnset: Boolean = true,
-    githubAuthToken: String? = getGithubAuthTokenOrNull(),
+    githubAuthToken: String? = getGithubAuthTokenOrNull()?.first,
 ): Flow<RegularActionVersions> {
     if (githubAuthToken == null && !reportWhenTokenUnset) {
         githubWarning("github auth token is required, but not set, skipping api calls")

--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutes.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutes.kt
@@ -26,7 +26,10 @@ private fun Route.metadata(refresh: Boolean = false) {
         val file = call.parameters["file"] ?: return@get call.respondNotFound()
         val actionCoords = call.parameters.extractActionCoords(extractVersion = false)
 
-        val bindingArtifacts = actionCoords.buildPackageArtifacts(githubAuthToken = getGithubAuthToken())
+        val (githubAuthToken, tokenType) = getGithubAuthToken()
+        // TODO: use tokenType to register a metric on the fallback
+        // TODO: what if getGithubAuthToken() returns null? Looks like destructuring asserts non-null?
+        val bindingArtifacts = actionCoords.buildPackageArtifacts(githubAuthToken = githubAuthToken)
         if (file in bindingArtifacts) {
             when (val artifact = bindingArtifacts[file]) {
                 is String -> call.respondText(text = artifact)


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/1880.

It's a draft of a change that will help register the metric we want, and won't make the shared module aware of metrics.