### PR TITLE
refactor: replace custom HTTP client with GitHub API library when fetching installation token

### DIFF
--- a/shared-internal/build.gradle.kts
+++ b/shared-internal/build.gradle.kts
@@ -20,7 +20,8 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:3.1.2")
     implementation("io.github.oshai:kotlin-logging:7.0.6")
     implementation("com.auth0:java-jwt:4.5.0")
-
+    implementation("org.kohsuke:github-api:2.0-rc.1")
+    
     // It's a workaround for a problem with Kotlin Scripting, and how it resolves
     // conflicting versions: https://youtrack.jetbrains.com/issue/KT-69145
     // As of adding it, ktor-serialization-kotlinx-json depends on kotlinx-io-core:0.4.0,

--- a/shared-internal/build.gradle.kts
+++ b/shared-internal/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:3.1.2")
     implementation("io.github.oshai:kotlin-logging:7.0.6")
     implementation("com.auth0:java-jwt:4.5.0")
-    implementation("org.kohsuke:github-api:2.0-rc.1")
+    implementation("org.kohsuke:github-api:1.327")
     
     // It's a workaround for a problem with Kotlin Scripting, and how it resolves
     // conflicting versions: https://youtrack.jetbrains.com/issue/KT-69145

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GitHubApp.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GitHubApp.kt
@@ -19,6 +19,7 @@ private var cachedAccessToken: GHAppInstallationToken? = null
  * Returns an installation access token for the GitHub app, usable with API call to GitHub.
  * If `null` is returned, it means that the environment wasn't configured to generate the token.
  */
+@Suppress("ReturnCount")
 fun getInstallationAccessToken(): String? {
     if (cachedAccessToken?.isExpired() == false) return cachedAccessToken!!.token
     val jwtToken = generateJWTToken() ?: return null
@@ -33,7 +34,7 @@ fun getInstallationAccessToken(): String? {
     return cachedAccessToken!!.token
 }
 
-private fun GHAppInstallationToken.isExpired() = expiresAt.toInstant() <= Instant.now()
+private fun GHAppInstallationToken.isExpired() = Instant.now() >= expiresAt.toInstant()
 
 @Suppress("ReturnCount", "MagicNumber")
 private fun generateJWTToken(): String? {

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GitHubApp.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GitHubApp.kt
@@ -3,80 +3,37 @@ package io.github.typesafegithub.workflows.shared.internal
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.logging.LogLevel.ALL
-import io.ktor.client.plugins.logging.Logger
-import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
-import kotlinx.serialization.json.Json
+import org.kohsuke.github.GHAppInstallationToken
+import org.kohsuke.github.GitHubBuilder
 import java.security.KeyFactory
 import java.security.interfaces.RSAPrivateKey
 import java.security.spec.PKCS8EncodedKeySpec
 import java.time.Instant
-import java.time.ZonedDateTime
 import java.util.Base64
 
 private val logger = logger { }
+
+private var cachedAccessToken: GHAppInstallationToken? = null
 
 /**
  * Returns an installation access token for the GitHub app, usable with API call to GitHub.
  * If `null` is returned, it means that the environment wasn't configured to generate the token.
  */
-@Suppress("ReturnCount")
-suspend fun getInstallationAccessToken(): String? {
+fun getInstallationAccessToken(): String? {
     if (cachedAccessToken?.isExpired() == false) return cachedAccessToken!!.token
     val jwtToken = generateJWTToken() ?: return null
-    val appInstallationId = System.getenv("APP_INSTALLATION_ID") ?: return null
+    val installationId = System.getenv("APP_INSTALLATION_ID") ?: return null
+
+    val gitHubApp = GitHubBuilder().withJwtToken(jwtToken).build().app
+
     cachedAccessToken =
-        httpClient
-            .post("https://api.github.com/app/installations/$appInstallationId/access_tokens") {
-                header("Accept", "application/vnd.github+json")
-                header("Authorization", "Bearer $jwtToken")
-                header("X-GitHub-Api-Version", "2022-11-28")
-            }.body()
+        gitHubApp.getInstallationById(installationId.toLong()).createToken().create().also {
+            logger.info { "Fetched new GitHub App installation access token for repository ${it.repositorySelection}" }
+        }
     return cachedAccessToken!!.token
 }
 
-private var cachedAccessToken: Token? = null
-
-@Suppress("ConstructorParameterNaming")
-@Serializable
-private data class Token(
-    val token: String,
-    val expires_at: String,
-    val permissions: Map<String, String>,
-    val repository_selection: String,
-) {
-    @Transient
-    private val expiresAtDateTime = ZonedDateTime.parse(expires_at)
-
-    fun isExpired() = ZonedDateTime.now().isAfter(expiresAtDateTime)
-}
-
-private val httpClient =
-    HttpClient {
-        val klogger = logger
-        install(Logging) {
-            logger =
-                object : Logger {
-                    override fun log(message: String) {
-                        klogger.trace { message }
-                    }
-                }
-            level = ALL
-        }
-        install(ContentNegotiation) {
-            json(
-                Json { ignoreUnknownKeys = false },
-            )
-        }
-    }
+private fun GHAppInstallationToken.isExpired() = expiresAt.toInstant() <= Instant.now()
 
 @Suppress("ReturnCount", "MagicNumber")
 private fun generateJWTToken(): String? {

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
@@ -11,15 +11,13 @@ private val logger = logger { }
  * The token may be of various kind, e.g. a Personal Access Token, or an
  * Application Installation Token.
  */
-fun getGithubAuthTokenOrNull(): String? =
-    runBlocking {
-        runCatching { getInstallationAccessToken() }
-            .onFailure {
-                logger.warn(it) {
-                    "Failed to get GitHub App Installation token, falling back to GITHUB_TOKEN."
-                }
-            }.getOrNull() ?: System.getenv("GITHUB_TOKEN")
-    }.also { if (it == null) logger.warn { ERROR_NO_CONFIGURATION } }
+fun getGithubAuthTokenOrNull(): String? {
+    val installationAccessToken = runCatching {
+        getInstallationAccessToken()
+    }.onFailure { logger.warn(it) { "Failed to get GitHub App Installation token." } }.getOrNull()
+
+    return installationAccessToken ?: System.getenv("GITHUB_TOKEN")
+}
 
 /**
  * Returns a token that should be used to make authorized calls to GitHub,

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
@@ -1,7 +1,6 @@
 package io.github.typesafegithub.workflows.shared.internal
 
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
-import kotlinx.coroutines.runBlocking
 
 private val logger = logger { }
 
@@ -12,9 +11,10 @@ private val logger = logger { }
  * Application Installation Token.
  */
 fun getGithubAuthTokenOrNull(): String? {
-    val installationAccessToken = runCatching {
-        getInstallationAccessToken()
-    }.onFailure { logger.warn(it) { "Failed to get GitHub App Installation token." } }.getOrNull()
+    val installationAccessToken =
+        runCatching {
+            getInstallationAccessToken()
+        }.onFailure { logger.warn(it) { "Failed to get GitHub App Installation token." } }.getOrNull()
 
     return installationAccessToken ?: System.getenv("GITHUB_TOKEN")
 }


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/1884.

Simplified access token handling by leveraging `org.kohsuke:github-api` library, removing custom HTTP client and serialization logic.