### PR TITLE
chore(shared-internal): add detekt linter

### DIFF
--- a/shared-internal/build.gradle.kts
+++ b/shared-internal/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     buildsrc.convention.publishing
 
     kotlin("plugin.serialization")
+    id("io.gitlab.arturbosch.detekt")
 }
 
 group = rootProject.group

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GitHubApp.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GitHubApp.kt
@@ -28,6 +28,7 @@ private val logger = logger { }
  * Returns an installation access token for the GitHub app, usable with API call to GitHub.
  * If `null` is returned, it means that the environment wasn't configured to generate the token.
  */
+@Suppress("ReturnCount")
 suspend fun getInstallationAccessToken(): String? {
     if (cachedAccessToken?.isExpired() == false) return cachedAccessToken!!.token
     val jwtToken = generateJWTToken() ?: return null
@@ -44,6 +45,7 @@ suspend fun getInstallationAccessToken(): String? {
 
 private var cachedAccessToken: Token? = null
 
+@Suppress("ConstructorParameterNaming")
 @Serializable
 private data class Token(
     val token: String,
@@ -76,6 +78,7 @@ private val httpClient =
         }
     }
 
+@Suppress("ReturnCount", "MagicNumber")
 private fun generateJWTToken(): String? {
     val key = loadRsaKey() ?: return null
     val appClientId = System.getenv("APP_CLIENT_ID") ?: return null
@@ -102,6 +105,8 @@ private fun loadRsaKey(): RSAPrivateKey? {
     return keyFactory.generatePrivate(keySpec) as RSAPrivateKey
 }
 
+@Suppress("MagicNumber")
 private fun Instant.minusMinutes(minutes: Long): Instant = minusSeconds(minutes * 60)
 
+@Suppress("MagicNumber")
 private fun Instant.plusMinutes(minutes: Long): Instant = plusSeconds(minutes * 60)

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubApi.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubApi.kt
@@ -79,7 +79,8 @@ private suspend fun fetchGithubRefs(
                     }
                 }
         ensure(response.status.isSuccess()) {
-            "Unexpected response when fetching refs from $url. Status: ${response.status}, response: ${response.bodyAsText()}"
+            "Unexpected response when fetching refs from $url. " +
+                "Status: ${response.status}, response: ${response.bodyAsText()}"
         }
         response.body()
     }

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/GithubUtils.kt
@@ -14,8 +14,11 @@ private val logger = logger { }
 fun getGithubAuthTokenOrNull(): String? =
     runBlocking {
         runCatching { getInstallationAccessToken() }
-            .onFailure { logger.warn(it) { "Failed to get GitHub App Installation token, falling back to GITHUB_TOKEN." } }
-            .getOrNull() ?: System.getenv("GITHUB_TOKEN")
+            .onFailure {
+                logger.warn(it) {
+                    "Failed to get GitHub App Installation token, falling back to GITHUB_TOKEN."
+                }
+            }.getOrNull() ?: System.getenv("GITHUB_TOKEN")
     }.also { if (it == null) logger.warn { ERROR_NO_CONFIGURATION } }
 
 /**

--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/model/Version.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/model/Version.kt
@@ -12,6 +12,7 @@ data class Version(
     val minor: Int = versionIntParts.getOrNull(1) ?: 0
     val patch: Int = versionIntParts.getOrNull(2) ?: 0
 
+    @Suppress("ReturnCount")
     override fun compareTo(other: Version): Int {
         versionParts.forEachIndexed { i, part ->
             val otherPart = other.versionParts.getOrNull(i)


### PR DESCRIPTION
Motivated by ability to detect redundant `suspend` modifier: https://detekt.dev/docs/rules/coroutines/#redundantsuspendmodifier, see https://github.com/typesafegithub/github-workflows-kt/pull/1889/files#r2030503149.