### PR TITLE
fix(library): do not check if .git is a dir

### DIFF
--- a/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/PathUtils.kt
+++ b/shared-internal/src/main/kotlin/io/github/typesafegithub/workflows/shared/internal/PathUtils.kt
@@ -3,10 +3,8 @@ package io.github.typesafegithub.workflows.shared.internal
 import java.nio.file.Path
 import kotlin.io.path.absolute
 import kotlin.io.path.exists
-import kotlin.io.path.isDirectory
 
 fun Path.findGitRoot(): Path =
     generateSequence(this.absolute()) { it.parent }
-        .firstOrNull {
-            it.resolve(".git")?.let { it.exists() && it.isDirectory() } ?: false
-        } ?: error("could not find a git root from ${this.absolute()}")
+        .firstOrNull { it.resolve(".git").exists() }
+        ?: error("could not find a git root from ${this.absolute()}")


### PR DESCRIPTION
Closes https://github.com/typesafegithub/github-workflows-kt/issues/1898.

`findGitDir` function is used to figure out where the script is run from, so it's a critical function that is called upon each YAML regeneration.

The check if it's a directory causes troubles when using git's worktrees. `.git` is a symlink to the real `.git` dir, so it's not a directory. Based on https://github.com/typesafegithub/github-workflows-kt/issues/1898#issuecomment-2806850958.