### PR TITLE
feat(library): add support for windows-2025 runner

### DIFF
--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/RunnerType.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/RunnerType.kt
@@ -39,6 +39,8 @@ public sealed interface RunnerType {
     public object MacOSLatest : RunnerType
 
     // Windows runners
+    public object Windows2025 : RunnerType
+
     public object Windows2022 : RunnerType
 
     public object Windows2019 : RunnerType

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/JobsToYaml.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/JobsToYaml.kt
@@ -13,6 +13,7 @@ import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
 import io.github.typesafegithub.workflows.domain.RunnerType.Windows2016
 import io.github.typesafegithub.workflows.domain.RunnerType.Windows2019
 import io.github.typesafegithub.workflows.domain.RunnerType.Windows2022
+import io.github.typesafegithub.workflows.domain.RunnerType.Windows2025
 import io.github.typesafegithub.workflows.domain.RunnerType.WindowsLatest
 import io.github.typesafegithub.workflows.internal.InternalGithubActionsApi
 
@@ -71,6 +72,7 @@ public fun RunnerType.toYaml(): Any =
         UbuntuLatest -> "ubuntu-latest"
         WindowsLatest -> "windows-latest"
         MacOSLatest -> "macos-latest"
+        Windows2025 -> "windows-2025"
         Windows2022 -> "windows-2022"
         Windows2019 -> "windows-2019"
         Windows2016 -> "windows-2016"


### PR DESCRIPTION
Noticed thanks to https://github.com/typesafegithub/github-workflows-kt/pull/1896.