### PR TITLE
chore(ci): use windows-latest instead of specific version in tests

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -17,7 +17,7 @@ import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.actions.SetupJava
 import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
-import io.github.typesafegithub.workflows.domain.RunnerType.Windows2022
+import io.github.typesafegithub.workflows.domain.RunnerType.WindowsLatest
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts
@@ -38,7 +38,7 @@ workflow(
     ),
     sourceFile = __FILE__,
 ) {
-    listOf(UbuntuLatest, Windows2022).forEach { runnerType ->
+    listOf(UbuntuLatest, WindowsLatest).forEach { runnerType ->
         job(
             id = "build-for-${runnerType::class.simpleName}",
             runsOn = runnerType,

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,8 +66,8 @@ jobs:
       env:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       run: './gradlew build'
-  build-for-Windows2022:
-    runs-on: 'windows-2022'
+  build-for-WindowsLatest:
+    runs-on: 'windows-latest'
     needs:
     - 'check_yaml_consistency'
     steps:


### PR DESCRIPTION
So that we don't have to maintain the version of Windows, like suggested in https://github.com/typesafegithub/github-workflows-kt/pull/1896.