### PR TITLE
fix(server): treat failed binding generation as internal server error

### DIFF
--- a/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
+++ b/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
@@ -27,9 +27,7 @@ class ArtifactRoutesTest :
                     val response = client.get("some-owner/some-action/v4/some-action-v4.pom")
 
                     // Then
-                    // This is incorrect, and will be fixed in
-                    //  https://github.com/typesafegithub/github-workflows-kt/pull/1924/
-                    response.status shouldBe HttpStatusCode.NotFound
+                    response.status shouldBe HttpStatusCode.InternalServerError
                 }
             }
         }


### PR DESCRIPTION
Before this PR, it was treated equally if a binding could not be found,
and if some exception happened during initial creating of the binding.
The exceptions were swallowed and the client received a 404 response.
If there was for example a compile error you already got internal server error.
But if for example Kotlin Poet throws an illegal argument exception,
then this did not propagate properly

Now exceptions are logged and the client gets an internal server error
if some exception happened and only a 404 if indeed the action was not found.

One such example is, if a typing has an `enum` with some option that contains a colon.
This resulted in an identifier generated that contains a colon which then produces an
exception due to the illegal identifier character.

