### PR TITLE
refactor(server): allow not passing Prometheus registry to most routes

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutes.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutes.kt
@@ -32,8 +32,10 @@ private val metadataCache =
             }
         }
 
-fun Routing.metadataRoutes(prometheusRegistry: PrometheusMeterRegistry) {
-    CaffeineCacheMetrics.monitor(prometheusRegistry, metadataCache.underlying(), "metadata_cache")
+fun Routing.metadataRoutes(prometheusRegistry: PrometheusMeterRegistry? = null) {
+    prometheusRegistry?.let {
+        CaffeineCacheMetrics.monitor(it, metadataCache.underlying(), "metadata_cache")
+    }
 
     route("{owner}/{name}/{file}") {
         metadata()


### PR DESCRIPTION
To improve testability, for the purpose of testing the fix in https://github.com/typesafegithub/github-workflows-kt/pull/1924