### PR TITLE
refactor(server): allow injecting bindings cache

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
@@ -38,14 +38,15 @@ fun main() {
     Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
         logger.error(throwable) { "Uncaught exception in thread $thread" }
     }
+    val bindingsCache = buildBindingsCache()
     embeddedServer(Netty, port = 8080) {
         installPlugins(prometheusRegistry)
 
         routing {
             internalRoutes(prometheusRegistry)
 
-            artifactRoutes(prometheusRegistry)
-            metadataRoutes(prometheusRegistry)
+            artifactRoutes(bindingsCache, prometheusRegistry)
+            metadataRoutes(bindingsCache, prometheusRegistry)
         }
     }.start(wait = true)
 }

--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutes.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutes.kt
@@ -1,6 +1,7 @@
 package io.github.typesafegithub.workflows.jitbindingserver
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import com.sksamuel.aedile.core.LoadingCache
 import com.sksamuel.aedile.core.asLoadingCache
 import com.sksamuel.aedile.core.refreshAfterWrite
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
@@ -21,32 +22,45 @@ private val logger = logger { }
 
 typealias MetadataResult = Result<Map<String, String>>
 
-private val metadataCache =
+@Suppress("ktlint:standard:function-signature") // Conflict with detekt.
+private fun buildMetadataCache(
+    bindingsCache: LoadingCache<ActionCoords, ArtifactResult>,
+): LoadingCache<ActionCoords, MetadataResult> =
     Caffeine
         .newBuilder()
         .refreshAfterWrite(1.hours)
         .recordStats()
         .asLoadingCache<ActionCoords, MetadataResult> {
             runCatching {
-                it.buildPackageArtifacts(githubAuthToken = getGithubAuthToken(), ::prefetchBindingArtifacts)
+                it.buildPackageArtifacts(
+                    githubAuthToken = getGithubAuthToken(),
+                    { coords -> prefetchBindingArtifacts(coords, bindingsCache) },
+                )
             }
         }
 
-fun Routing.metadataRoutes(prometheusRegistry: PrometheusMeterRegistry? = null) {
+fun Routing.metadataRoutes(
+    bindingsCache: LoadingCache<ActionCoords, ArtifactResult>,
+    prometheusRegistry: PrometheusMeterRegistry? = null,
+) {
+    val metadataCache = buildMetadataCache(bindingsCache)
     prometheusRegistry?.let {
         CaffeineCacheMetrics.monitor(it, metadataCache.underlying(), "metadata_cache")
     }
 
     route("{owner}/{name}/{file}") {
-        metadata()
+        metadata(metadataCache)
     }
 
     route("/refresh/{owner}/{name}/{file}") {
-        metadata(refresh = true)
+        metadata(metadataCache, refresh = true)
     }
 }
 
-private fun Route.metadata(refresh: Boolean = false) {
+private fun Route.metadata(
+    metadataCache: LoadingCache<ActionCoords, MetadataResult>,
+    refresh: Boolean = false,
+) {
     get {
         val actionCoords = call.parameters.extractActionCoords(extractVersion = false)
 


### PR DESCRIPTION
To improve testability, for the purpose of testing the fix in https://github.com/typesafegithub/github-workflows-kt/pull/1924