### PR TITLE
refactor(server): do not leak cache in tests

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutes.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutes.kt
@@ -1,16 +1,12 @@
 package io.github.typesafegithub.workflows.jitbindingserver
 
-import com.github.benmanes.caffeine.cache.Caffeine
 import com.sksamuel.aedile.core.LoadingCache
-import com.sksamuel.aedile.core.asLoadingCache
-import com.sksamuel.aedile.core.refreshAfterWrite
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.prettyPrint
 import io.github.typesafegithub.workflows.mavenbinding.Artifact
 import io.github.typesafegithub.workflows.mavenbinding.JarArtifact
 import io.github.typesafegithub.workflows.mavenbinding.TextArtifact
-import io.github.typesafegithub.workflows.mavenbinding.buildVersionArtifacts
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
@@ -28,22 +24,12 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlin.time.Duration.Companion.hours
 
 private val logger = logger { }
 
 typealias ArtifactResult = Result<Map<String, Artifact>?>
 
 private val prefetchScope = CoroutineScope(Dispatchers.IO)
-
-internal fun buildBindingsCache(
-    buildVersionArtifacts: (ActionCoords) -> Map<String, Artifact>? = ::buildVersionArtifacts,
-): LoadingCache<ActionCoords, ArtifactResult> =
-    Caffeine
-        .newBuilder()
-        .refreshAfterWrite(1.hours)
-        .recordStats()
-        .asLoadingCache<ActionCoords, ArtifactResult> { runCatching { buildVersionArtifacts(it) } }
 
 fun Routing.artifactRoutes(
     bindingsCache: LoadingCache<ActionCoords, ArtifactResult>,

--- a/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
+++ b/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
@@ -6,7 +6,6 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 
 class ArtifactRoutesTest :
@@ -16,15 +15,11 @@ class ArtifactRoutesTest :
                 testApplication {
                     // Given
                     application {
-                        routing {
-                            artifactRoutes(
-                                buildBindingsCache(
-                                    buildVersionArtifacts = {
-                                        mapOf("some-action-v4.pom" to TextArtifact { "Some POM contents" })
-                                    },
-                                ),
-                            )
-                        }
+                        appModule(
+                            buildVersionArtifacts = {
+                                mapOf("some-action-v4.pom" to TextArtifact { "Some POM contents" })
+                            },
+                        )
                     }
 
                     // When
@@ -40,13 +35,9 @@ class ArtifactRoutesTest :
                 testApplication {
                     // Given
                     application {
-                        routing {
-                            artifactRoutes(
-                                buildBindingsCache(
-                                    buildVersionArtifacts = { null },
-                                ),
-                            )
-                        }
+                        appModule(
+                            buildVersionArtifacts = { null },
+                        )
                     }
 
                     // When
@@ -61,13 +52,9 @@ class ArtifactRoutesTest :
                 testApplication {
                     // Given
                     application {
-                        routing {
-                            artifactRoutes(
-                                buildBindingsCache(
-                                    buildVersionArtifacts = { error("An internal error occurred!") },
-                                ),
-                            )
-                        }
+                        appModule(
+                            buildVersionArtifacts = { error("An internal error occurred!") },
+                        )
                     }
 
                     // When


### PR DESCRIPTION
Thanks to this, the test aren't aware of an implementation detail of the server: the cache.
We wrap the whole server config in an `appModule`, and inject a piece of logic exposed by `maven-binding-builder` Gradle module. This piece is the only thing we need to mock right now in the test. It makes the test less brittle and couple with the implementation (although some necessary coupling is still there).