### PR TITLE
refactor(server): rename typealiases for cached objects

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutes.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutes.kt
@@ -27,12 +27,12 @@ import kotlinx.coroutines.launch
 
 private val logger = logger { }
 
-typealias ArtifactResult = Result<Map<String, Artifact>?>
+typealias CachedVersionArtifact = Result<Map<String, Artifact>?>
 
 private val prefetchScope = CoroutineScope(Dispatchers.IO)
 
 fun Routing.artifactRoutes(
-    bindingsCache: LoadingCache<ActionCoords, ArtifactResult>,
+    bindingsCache: LoadingCache<ActionCoords, CachedVersionArtifact>,
     prometheusRegistry: PrometheusMeterRegistry? = null,
 ) {
     prometheusRegistry?.let {
@@ -50,7 +50,7 @@ fun Routing.artifactRoutes(
 
 private fun Route.artifact(
     prometheusRegistry: PrometheusMeterRegistry?,
-    bindingsCache: LoadingCache<ActionCoords, ArtifactResult>,
+    bindingsCache: LoadingCache<ActionCoords, CachedVersionArtifact>,
     refresh: Boolean = false,
 ) {
     headArtifact(bindingsCache, prometheusRegistry, refresh)
@@ -58,7 +58,7 @@ private fun Route.artifact(
 }
 
 private fun Route.headArtifact(
-    bindingsCache: LoadingCache<ActionCoords, ArtifactResult>,
+    bindingsCache: LoadingCache<ActionCoords, CachedVersionArtifact>,
     prometheusRegistry: PrometheusMeterRegistry?,
     refresh: Boolean,
 ) {
@@ -78,7 +78,7 @@ private fun Route.headArtifact(
 }
 
 private fun Route.getArtifact(
-    bindingsCache: LoadingCache<ActionCoords, ArtifactResult>,
+    bindingsCache: LoadingCache<ActionCoords, CachedVersionArtifact>,
     prometheusRegistry: PrometheusMeterRegistry?,
     refresh: Boolean,
 ) {
@@ -102,7 +102,7 @@ private fun Route.getArtifact(
 
 internal fun prefetchBindingArtifacts(
     coords: Collection<ActionCoords>,
-    bindingsCache: LoadingCache<ActionCoords, ArtifactResult>,
+    bindingsCache: LoadingCache<ActionCoords, CachedVersionArtifact>,
 ) {
     prefetchScope.launch {
         bindingsCache.getAll(coords)
@@ -111,7 +111,7 @@ internal fun prefetchBindingArtifacts(
 
 private suspend fun ApplicationCall.toBindingArtifacts(
     refresh: Boolean,
-    bindingsCache: LoadingCache<ActionCoords, ArtifactResult>,
+    bindingsCache: LoadingCache<ActionCoords, CachedVersionArtifact>,
 ): Map<String, Artifact>? {
     val actionCoords = parameters.extractActionCoords(extractVersion = true)
 

--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
@@ -77,24 +77,24 @@ fun Application.appModule(
 
 private fun buildBindingsCache(
     buildVersionArtifacts: (ActionCoords) -> Map<String, Artifact>?,
-): LoadingCache<ActionCoords, ArtifactResult> =
+): LoadingCache<ActionCoords, CachedVersionArtifact> =
     Caffeine
         .newBuilder()
         .refreshAfterWrite(1.hours)
         .recordStats()
-        .asLoadingCache<ActionCoords, ArtifactResult> { runCatching { buildVersionArtifacts(it) } }
+        .asLoadingCache<ActionCoords, CachedVersionArtifact> { runCatching { buildVersionArtifacts(it) } }
 
 @Suppress("ktlint:standard:function-signature") // Conflict with detekt.
 private fun buildMetadataCache(
-    bindingsCache: LoadingCache<ActionCoords, ArtifactResult>,
+    bindingsCache: LoadingCache<ActionCoords, CachedVersionArtifact>,
     buildPackageArtifacts: suspend (ActionCoords, String, (Collection<ActionCoords>) -> Unit) -> Map<String, String>,
     getGithubAuthToken: () -> String,
-): LoadingCache<ActionCoords, MetadataResult> =
+): LoadingCache<ActionCoords, CachedMetadataArtifact> =
     Caffeine
         .newBuilder()
         .refreshAfterWrite(1.hours)
         .recordStats()
-        .asLoadingCache<ActionCoords, MetadataResult> {
+        .asLoadingCache<ActionCoords, CachedMetadataArtifact> {
             runCatching {
                 buildPackageArtifacts(
                     it,

--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutes.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutes.kt
@@ -14,10 +14,10 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 
 private val logger = logger { }
 
-typealias MetadataResult = Result<Map<String, String>>
+typealias CachedMetadataArtifact = Result<Map<String, String>>
 
 fun Routing.metadataRoutes(
-    metadataCache: LoadingCache<ActionCoords, MetadataResult>,
+    metadataCache: LoadingCache<ActionCoords, CachedMetadataArtifact>,
     prometheusRegistry: PrometheusMeterRegistry? = null,
 ) {
     prometheusRegistry?.let {
@@ -34,7 +34,7 @@ fun Routing.metadataRoutes(
 }
 
 private fun Route.metadata(
-    metadataCache: LoadingCache<ActionCoords, MetadataResult>,
+    metadataCache: LoadingCache<ActionCoords, CachedMetadataArtifact>,
     refresh: Boolean = false,
 ) {
     get {


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/1938.

We're going to get rid of `Result` in the type, so it makes sense to call the alias in a more generic way.