### PR TITLE
refactor(server): add wrapping type for version artifact results

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/Main.kt
@@ -6,7 +6,7 @@ import com.sksamuel.aedile.core.asLoadingCache
 import com.sksamuel.aedile.core.refreshAfterWrite
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
-import io.github.typesafegithub.workflows.mavenbinding.Artifact
+import io.github.typesafegithub.workflows.mavenbinding.VersionArtifacts
 import io.github.typesafegithub.workflows.mavenbinding.buildPackageArtifacts
 import io.github.typesafegithub.workflows.mavenbinding.buildVersionArtifacts
 import io.github.typesafegithub.workflows.shared.internal.getGithubAuthToken
@@ -59,7 +59,7 @@ fun main() {
 }
 
 fun Application.appModule(
-    buildVersionArtifacts: (ActionCoords) -> Map<String, Artifact>?,
+    buildVersionArtifacts: (ActionCoords) -> VersionArtifacts?,
     buildPackageArtifacts: suspend (ActionCoords, String, (Collection<ActionCoords>) -> Unit) -> Map<String, String>,
     getGithubAuthToken: () -> String,
 ) {
@@ -76,7 +76,7 @@ fun Application.appModule(
 }
 
 private fun buildBindingsCache(
-    buildVersionArtifacts: (ActionCoords) -> Map<String, Artifact>?,
+    buildVersionArtifacts: (ActionCoords) -> VersionArtifacts?,
 ): LoadingCache<ActionCoords, CachedVersionArtifact> =
     Caffeine
         .newBuilder()

--- a/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
+++ b/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
@@ -1,7 +1,6 @@
 package io.github.typesafegithub.workflows.jitbindingserver
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
-import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
 import io.github.typesafegithub.workflows.mavenbinding.TextArtifact
 import io.github.typesafegithub.workflows.mavenbinding.VersionArtifacts
 import io.kotest.core.spec.style.FunSpec
@@ -25,7 +24,6 @@ class ArtifactRoutesTest :
                             buildVersionArtifacts = {
                                 VersionArtifacts(
                                     files = mapOf("some-action-v4.pom" to TextArtifact { "Some POM contents" }),
-                                    typingActualSource = TypingActualSource.TYPING_CATALOG,
                                 )
                             },
                             // Irrelevant for these tests.
@@ -91,7 +89,6 @@ class ArtifactRoutesTest :
                         Exception("An internal error occurred!") andThen
                         VersionArtifacts(
                             files = mapOf("some-action-v4.pom" to TextArtifact { "Some POM contents" }),
-                            typingActualSource = TypingActualSource.TYPING_CATALOG,
                         )
                     application {
                         appModule(

--- a/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
+++ b/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
@@ -1,7 +1,9 @@
 package io.github.typesafegithub.workflows.jitbindingserver
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
 import io.github.typesafegithub.workflows.mavenbinding.TextArtifact
+import io.github.typesafegithub.workflows.mavenbinding.VersionArtifacts
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
@@ -21,7 +23,10 @@ class ArtifactRoutesTest :
                     application {
                         appModule(
                             buildVersionArtifacts = {
-                                mapOf("some-action-v4.pom" to TextArtifact { "Some POM contents" })
+                                VersionArtifacts(
+                                    files = mapOf("some-action-v4.pom" to TextArtifact { "Some POM contents" }),
+                                    typingActualSource = TypingActualSource.TYPING_CATALOG,
+                                )
                             },
                             // Irrelevant for these tests.
                             buildPackageArtifacts = { _, _, _ -> emptyMap() },
@@ -81,10 +86,13 @@ class ArtifactRoutesTest :
             test("when binding generation fails and then succeeds, and two requests are made") {
                 testApplication {
                     // Given
-                    val mockBuildVersionArtifacts = mockk<(ActionCoords) -> Map<String, TextArtifact>?>()
+                    val mockBuildVersionArtifacts = mockk<(ActionCoords) -> VersionArtifacts?>()
                     every { mockBuildVersionArtifacts(any()) } throws
                         Exception("An internal error occurred!") andThen
-                        mapOf("some-action-v4.pom" to TextArtifact { "Some POM contents" })
+                        VersionArtifacts(
+                            files = mapOf("some-action-v4.pom" to TextArtifact { "Some POM contents" }),
+                            typingActualSource = TypingActualSource.TYPING_CATALOG,
+                        )
                     application {
                         appModule(
                             buildVersionArtifacts = mockBuildVersionArtifacts,

--- a/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutesTest.kt
+++ b/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutesTest.kt
@@ -1,6 +1,7 @@
 package io.github.typesafegithub.workflows.jitbindingserver
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.mavenbinding.VersionArtifacts
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
@@ -24,7 +25,12 @@ class MetadataRoutesTest :
                             },
                             getGithubAuthToken = { "some-token" },
                             // Irrelevant for these tests.
-                            buildVersionArtifacts = { emptyMap() },
+                            buildVersionArtifacts = {
+                                VersionArtifacts(
+                                    files = emptyMap(),
+                                    typingActualSource = null,
+                                )
+                            },
                         )
                     }
 
@@ -47,7 +53,12 @@ class MetadataRoutesTest :
                             },
                             getGithubAuthToken = { "some-token" },
                             // Irrelevant for these tests.
-                            buildVersionArtifacts = { emptyMap() },
+                            buildVersionArtifacts = {
+                                VersionArtifacts(
+                                    files = emptyMap(),
+                                    typingActualSource = null,
+                                )
+                            },
                         )
                     }
 
@@ -69,7 +80,12 @@ class MetadataRoutesTest :
                             },
                             getGithubAuthToken = { "some-token" },
                             // Irrelevant for these tests.
-                            buildVersionArtifacts = { emptyMap() },
+                            buildVersionArtifacts = {
+                                VersionArtifacts(
+                                    files = emptyMap(),
+                                    typingActualSource = null,
+                                )
+                            },
                         )
                     }
 
@@ -100,7 +116,12 @@ class MetadataRoutesTest :
                             buildPackageArtifacts = mockBuildPackageArtifacts,
                             getGithubAuthToken = { "some-token" },
                             // Irrelevant for these tests.
-                            buildVersionArtifacts = { emptyMap() },
+                            buildVersionArtifacts = {
+                                VersionArtifacts(
+                                    files = emptyMap(),
+                                    typingActualSource = null,
+                                )
+                            },
                         )
                     }
 

--- a/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutesTest.kt
+++ b/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutesTest.kt
@@ -28,7 +28,6 @@ class MetadataRoutesTest :
                             buildVersionArtifacts = {
                                 VersionArtifacts(
                                     files = emptyMap(),
-                                    typingActualSource = null,
                                 )
                             },
                         )
@@ -56,7 +55,6 @@ class MetadataRoutesTest :
                             buildVersionArtifacts = {
                                 VersionArtifacts(
                                     files = emptyMap(),
-                                    typingActualSource = null,
                                 )
                             },
                         )
@@ -83,7 +81,6 @@ class MetadataRoutesTest :
                             buildVersionArtifacts = {
                                 VersionArtifacts(
                                     files = emptyMap(),
-                                    typingActualSource = null,
                                 )
                             },
                         )
@@ -119,7 +116,6 @@ class MetadataRoutesTest :
                             buildVersionArtifacts = {
                                 VersionArtifacts(
                                     files = emptyMap(),
-                                    typingActualSource = null,
                                 )
                             },
                         )

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/JarBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/JarBuilding.kt
@@ -4,6 +4,7 @@ package io.github.typesafegithub.workflows.mavenbinding
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestForVersion
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
 import io.github.typesafegithub.workflows.actionbindinggenerator.generation.ActionBinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.generation.generateBinding
 import org.jetbrains.kotlin.cli.common.ExitCode
@@ -24,6 +25,7 @@ import kotlin.io.path.writeText
 internal data class Jars(
     val mainJar: () -> ByteArray,
     val sourcesJar: () -> ByteArray,
+    val typingActualSource: TypingActualSource?,
 )
 
 internal fun ActionCoords.buildJars(): Jars? {
@@ -53,6 +55,7 @@ internal fun ActionCoords.buildJars(): Jars? {
     return Jars(
         mainJar = { mainJar },
         sourcesJar = { sourcesJar },
+        typingActualSource = binding.firstNotNullOfOrNull { it.typingActualSource },
     )
 }
 

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/JarBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/JarBuilding.kt
@@ -4,7 +4,6 @@ package io.github.typesafegithub.workflows.mavenbinding
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestForVersion
-import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
 import io.github.typesafegithub.workflows.actionbindinggenerator.generation.ActionBinding
 import io.github.typesafegithub.workflows.actionbindinggenerator.generation.generateBinding
 import org.jetbrains.kotlin.cli.common.ExitCode
@@ -25,7 +24,6 @@ import kotlin.io.path.writeText
 internal data class Jars(
     val mainJar: () -> ByteArray,
     val sourcesJar: () -> ByteArray,
-    val typingActualSource: TypingActualSource?,
 )
 
 internal fun ActionCoords.buildJars(): Jars? {
@@ -55,7 +53,6 @@ internal fun ActionCoords.buildJars(): Jars? {
     return Jars(
         mainJar = { mainJar },
         sourcesJar = { sourcesJar },
-        typingActualSource = binding.firstNotNullOfOrNull { it.typingActualSource },
     )
 }
 

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/VersionArtifactsBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/VersionArtifactsBuilding.kt
@@ -1,6 +1,7 @@
 package io.github.typesafegithub.workflows.mavenbinding
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
 
 sealed interface Artifact
 
@@ -12,7 +13,12 @@ data class JarArtifact(
     val data: () -> ByteArray,
 ) : Artifact
 
-fun buildVersionArtifacts(actionCoords: ActionCoords): Map<String, Artifact>? {
+data class VersionArtifacts(
+    val files: Map<String, Artifact>,
+    val typingActualSource: TypingActualSource?,
+)
+
+fun buildVersionArtifacts(actionCoords: ActionCoords): VersionArtifacts? {
     with(actionCoords) {
         val jars = buildJars() ?: return null
         val pom = buildPomFile()
@@ -40,27 +46,31 @@ fun buildVersionArtifacts(actionCoords: ActionCoords): Map<String, Artifact>? {
                 sourcesJarSha512Checksum,
             )
         }
-        return mapOf(
-            "$mavenName-$version.jar" to JarArtifact(jars.mainJar),
-            "$mavenName-$version.jar.md5" to TextArtifact { mainJarMd5Checksum },
-            "$mavenName-$version.jar.sha1" to TextArtifact { mainJarSha1Checksum },
-            "$mavenName-$version.jar.sha256" to TextArtifact { mainJarSha256Checksum },
-            "$mavenName-$version.jar.sha512" to TextArtifact { mainJarSha512Checksum },
-            "$mavenName-$version-sources.jar" to JarArtifact(jars.sourcesJar),
-            "$mavenName-$version-sources.jar.md5" to TextArtifact { sourcesJarMd5Checksum },
-            "$mavenName-$version-sources.jar.sha1" to TextArtifact { sourcesJarSha1Checksum },
-            "$mavenName-$version-sources.jar.sha256" to TextArtifact { sourcesJarSha256Checksum },
-            "$mavenName-$version-sources.jar.sha512" to TextArtifact { sourcesJarSha512Checksum },
-            "$mavenName-$version.pom" to TextArtifact { pom },
-            "$mavenName-$version.pom.md5" to TextArtifact { pom.md5Checksum() },
-            "$mavenName-$version.pom.sha1" to TextArtifact { pom.sha1Checksum() },
-            "$mavenName-$version.pom.sha256" to TextArtifact { pom.sha256Checksum() },
-            "$mavenName-$version.pom.sha512" to TextArtifact { pom.sha512Checksum() },
-            "$mavenName-$version.module" to TextArtifact { module },
-            "$mavenName-$version.module.md5" to TextArtifact { module.md5Checksum() },
-            "$mavenName-$version.module.sha1" to TextArtifact { module.sha1Checksum() },
-            "$mavenName-$version.module.sha256" to TextArtifact { module.sha256Checksum() },
-            "$mavenName-$version.module.sha512" to TextArtifact { module.sha512Checksum() },
+        return VersionArtifacts(
+            files =
+                mapOf(
+                    "$mavenName-$version.jar" to JarArtifact(jars.mainJar),
+                    "$mavenName-$version.jar.md5" to TextArtifact { mainJarMd5Checksum },
+                    "$mavenName-$version.jar.sha1" to TextArtifact { mainJarSha1Checksum },
+                    "$mavenName-$version.jar.sha256" to TextArtifact { mainJarSha256Checksum },
+                    "$mavenName-$version.jar.sha512" to TextArtifact { mainJarSha512Checksum },
+                    "$mavenName-$version-sources.jar" to JarArtifact(jars.sourcesJar),
+                    "$mavenName-$version-sources.jar.md5" to TextArtifact { sourcesJarMd5Checksum },
+                    "$mavenName-$version-sources.jar.sha1" to TextArtifact { sourcesJarSha1Checksum },
+                    "$mavenName-$version-sources.jar.sha256" to TextArtifact { sourcesJarSha256Checksum },
+                    "$mavenName-$version-sources.jar.sha512" to TextArtifact { sourcesJarSha512Checksum },
+                    "$mavenName-$version.pom" to TextArtifact { pom },
+                    "$mavenName-$version.pom.md5" to TextArtifact { pom.md5Checksum() },
+                    "$mavenName-$version.pom.sha1" to TextArtifact { pom.sha1Checksum() },
+                    "$mavenName-$version.pom.sha256" to TextArtifact { pom.sha256Checksum() },
+                    "$mavenName-$version.pom.sha512" to TextArtifact { pom.sha512Checksum() },
+                    "$mavenName-$version.module" to TextArtifact { module },
+                    "$mavenName-$version.module.md5" to TextArtifact { module.md5Checksum() },
+                    "$mavenName-$version.module.sha1" to TextArtifact { module.sha1Checksum() },
+                    "$mavenName-$version.module.sha256" to TextArtifact { module.sha256Checksum() },
+                    "$mavenName-$version.module.sha512" to TextArtifact { module.sha512Checksum() },
+                ),
+            typingActualSource = jars.typingActualSource,
         )
     }
 }

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/VersionArtifactsBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/VersionArtifactsBuilding.kt
@@ -1,7 +1,6 @@
 package io.github.typesafegithub.workflows.mavenbinding
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
-import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
 
 sealed interface Artifact
 
@@ -15,7 +14,6 @@ data class JarArtifact(
 
 data class VersionArtifacts(
     val files: Map<String, Artifact>,
-    val typingActualSource: TypingActualSource?,
 )
 
 fun buildVersionArtifacts(actionCoords: ActionCoords): VersionArtifacts? {
@@ -70,7 +68,6 @@ fun buildVersionArtifacts(actionCoords: ActionCoords): VersionArtifacts? {
                     "$mavenName-$version.module.sha256" to TextArtifact { module.sha256Checksum() },
                     "$mavenName-$version.module.sha512" to TextArtifact { module.sha512Checksum() },
                 ),
-            typingActualSource = jars.typingActualSource,
         )
     }
 }


### PR DESCRIPTION
This refactoring is necessary because we're going to add another piece of info returned from binding generation.