### PR TITLE
test(library): add basic assertion for env context's tests

### DIFF
--- a/.github/workflows/end-to-end-tests.main.kts
+++ b/.github/workflows/end-to-end-tests.main.kts
@@ -73,7 +73,7 @@ workflow(
             id = "test_job_1",
             runsOn = RunnerType.UbuntuLatest,
             env = mapOf(
-                GREETING to "World",
+                "GREETING" to "Hello",
             ),
             permissions = mapOf(
                 Permission.Actions to Mode.Read,
@@ -186,9 +186,17 @@ workflow(
             run(
                 name = "Custom environment variable",
                 env = mapOf(
-                    FIRST_NAME to "Patrick",
+                    "FIRST_NAME" to "Patrick",
                 ),
-                command = "echo $GREETING $FIRST_NAME",
+                command = """
+                    cat << EOF > actual
+                    $GREETING $FIRST_NAME
+                    EOF
+                    cat << EOF > expected
+                    Hello Patrick
+                    EOF
+                    diff actual expected
+                """.trimIndent(),
             )
             run(
                 name = "Encrypted secret",

--- a/.github/workflows/end-to-end-tests.main.kts
+++ b/.github/workflows/end-to-end-tests.main.kts
@@ -193,7 +193,7 @@ workflow(
                     $GREETING $FIRST_NAME
                     EOF
                     cat << EOF > expected
-                    Hello Patrick
+                    Hello Patrick2
                     EOF
                     diff actual expected
                 """.trimIndent(),

--- a/.github/workflows/end-to-end-tests.main.kts
+++ b/.github/workflows/end-to-end-tests.main.kts
@@ -73,7 +73,7 @@ workflow(
             id = "test_job_1",
             runsOn = RunnerType.UbuntuLatest,
             env = mapOf(
-                "GREETING" to "Hello",
+                GREETING to "World",
             ),
             permissions = mapOf(
                 Permission.Actions to Mode.Read,
@@ -186,15 +186,20 @@ workflow(
             run(
                 name = "Custom environment variable",
                 env = mapOf(
-                    "FIRST_NAME" to "Patrick",
+                    FIRST_NAME to "Patrick",
                 ),
+                // The assertion below presents the current, undesired behavior related to
+                // env vars, used either from shell or GitHub Actions expressions.
+                // TODO: fix in https://github.com/typesafegithub/github-workflows-kt/issues/1956
                 command = """
                     cat << EOF > actual
                     $GREETING $FIRST_NAME
                     EOF
+
                     cat << EOF > expected
-                    Hello Patrick2
+
                     EOF
+
                     diff actual expected
                 """.trimIndent(),
             )

--- a/.github/workflows/end-to-end-tests.main.kts
+++ b/.github/workflows/end-to-end-tests.main.kts
@@ -193,11 +193,11 @@ workflow(
                 // TODO: fix in https://github.com/typesafegithub/github-workflows-kt/issues/1956
                 command = """
                     cat << EOF > actual
-                    $GREETING $FIRST_NAME
+                    $GREETING-$FIRST_NAME
                     EOF
 
                     cat << EOF > expected
-
+                    -
                     EOF
 
                     diff actual expected

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -44,7 +44,7 @@ jobs:
     needs:
     - 'check_yaml_consistency'
     env:
-      GREETING: 'Hello'
+      $GREETING: 'World'
     outputs:
       scriptKey: '${{ steps.step-20.outputs.key }}'
       scriptKey2: '${{ steps.step-20.outputs.key2 }}'
@@ -98,14 +98,16 @@ jobs:
     - id: 'step-10'
       name: 'Custom environment variable'
       env:
-        FIRST_NAME: 'Patrick'
+        $FIRST_NAME: 'Patrick'
       run: |-
         cat << EOF > actual
         $GREETING $FIRST_NAME
         EOF
+
         cat << EOF > expected
-        Hello Patrick2
+
         EOF
+
         diff actual expected
     - id: 'step-11'
       name: 'Encrypted secret'

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -104,7 +104,7 @@ jobs:
         $GREETING $FIRST_NAME
         EOF
         cat << EOF > expected
-        Hello Patrick
+        Hello Patrick2
         EOF
         diff actual expected
     - id: 'step-11'

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -101,11 +101,11 @@ jobs:
         $FIRST_NAME: 'Patrick'
       run: |-
         cat << EOF > actual
-        $GREETING $FIRST_NAME
+        $GREETING-$FIRST_NAME
         EOF
 
         cat << EOF > expected
-
+        -
         EOF
 
         diff actual expected

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -44,7 +44,7 @@ jobs:
     needs:
     - 'check_yaml_consistency'
     env:
-      $GREETING: 'World'
+      GREETING: 'Hello'
     outputs:
       scriptKey: '${{ steps.step-20.outputs.key }}'
       scriptKey2: '${{ steps.step-20.outputs.key2 }}'
@@ -98,8 +98,15 @@ jobs:
     - id: 'step-10'
       name: 'Custom environment variable'
       env:
-        $FIRST_NAME: 'Patrick'
-      run: 'echo $GREETING $FIRST_NAME'
+        FIRST_NAME: 'Patrick'
+      run: |-
+        cat << EOF > actual
+        $GREETING $FIRST_NAME
+        EOF
+        cat << EOF > expected
+        Hello Patrick
+        EOF
+        diff actual expected
     - id: 'step-11'
       name: 'Encrypted secret'
       env:


### PR DESCRIPTION
This PR attempts to better capture the current current incorrect behavior for `Contexts.env`.

Part of https://github.com/typesafegithub/github-workflows-kt/issues/1956.