### PR TITLE
feat(abg): mark typed bindings from fallback version as deprecated

### DIFF
--- a/action-binding-generator/api/action-binding-generator.api
+++ b/action-binding-generator/api/action-binding-generator.api
@@ -26,6 +26,23 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/dom
 	public static final fun isTopLevel (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;)Z
 }
 
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;Z)V
+	public synthetic fun <init> (Ljava/util/Map;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/util/Map;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;Z)Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;Ljava/util/Map;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;ZILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFromFallbackVersion ()Z
+	public final fun getInputTypings ()Ljava/util/Map;
+	public final fun getSource ()Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/domain/CommitHash : io/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -85,8 +102,8 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/gen
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationKt {
-	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;)Ljava/util/List;
-	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;)Ljava/util/List;
+	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;ILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/metadata/Input {

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings.kt
@@ -1,0 +1,9 @@
+package io.github.typesafegithub.workflows.actionbindinggenerator.domain
+
+import io.github.typesafegithub.workflows.actionbindinggenerator.typing.Typing
+
+public data class ActionTypings(
+    val inputTypings: Map<String, Typing> = emptyMap(),
+    val source: TypingActualSource? = null,
+    val fromFallbackVersion: Boolean = false,
+)

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
@@ -102,12 +102,15 @@ public fun ActionCoords.generateBinding(
                     className = className,
                     deprecationMessage =
                         inputTypingsResolved.takeIf { it.fromFallbackVersion }?.let {
-                            "These typings were create from a fallback version in " +
-                                "https://github.com/typesafegithub/github-actions-typing-catalog, " +
-                                "as soon as typings for this version are added, there could be breaking changes, " +
-                                "and you need to delete these typings from your local Maven cache typically found " +
-                                "in ~/.m2/repository/ to get the updated typing. Consider contributing updated " +
-                                "typings to the catalog before using this version."
+                            "This typed binding was created from typings for an older version in " +
+                                "https://github.com/typesafegithub/github-actions-typing-catalog. " +
+                                "As soon as typings for the requested version are added, there could be breaking " +
+                                "changes, and you need to delete these typings from your local Maven cache typically " +
+                                "found in ~/.m2/repository/ to get the updated typing. In some cases, though, you " +
+                                "may be lucky and things will work fine. To be on the safe side, consider " +
+                                "contributing updated typings to the catalog before using this version, or even " +
+                                "better: ask the action's owner to host the typings together with the action using " +
+                                "https://github.com/typesafegithub/github-actions-typing."
                         },
                 )
             ActionBinding(
@@ -193,7 +196,7 @@ private fun generateActionClass(
         .classBuilder(className)
         .addModifiers(KModifier.DATA)
         .addKdocIfNotEmpty(actionKdoc(metadata, coords, untypedClass))
-        .replaceWith(deprecationMessage, replaceWith)
+        .markDeprecated(deprecationMessage, replaceWith)
         .addClassConstructorAnnotation()
         .inheritsFromRegularAction(coords, metadata, className)
         .primaryConstructor(metadata.primaryConstructor(inputTypings, coords, className, untypedClass))
@@ -386,7 +389,7 @@ private fun Metadata.linkedMapOfInputs(
     }
 }
 
-private fun TypeSpec.Builder.replaceWith(
+private fun TypeSpec.Builder.markDeprecated(
     deprecationMessage: String?,
     replaceWith: CodeBlock?,
 ): TypeSpec.Builder {

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/ActionTypes.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/ActionTypes.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 internal data class ActionTypes(
     val inputs: Map<String, ActionType>? = null,
     val outputs: Map<String, ActionType>? = null,
+    val fromFallbackVersion: Boolean = false,
 )
 
 @Serializable

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
@@ -104,14 +104,12 @@ private fun ActionCoords.fetchTypingsForOlderVersionFromCatalog(fetchUri: (URI) 
     return fetchTypingsFromUrl(
         url = adjustedCoords.actionTypesFromCatalog(),
         fetchUri = fetchUri,
-        fromFallbackVersion = true,
-    )
+    )?.copy(fromFallbackVersion = true)
 }
 
 private fun fetchTypingsFromUrl(
     url: String,
     fetchUri: (URI) -> String,
-    fromFallbackVersion: Boolean = false,
 ): ActionTypes? {
     val typesMetadataYml =
         try {
@@ -120,9 +118,7 @@ private fun fetchTypingsFromUrl(
         } catch (e: IOException) {
             null
         } ?: return null
-    return yaml.decodeFromStringOrDefaultIfEmpty(typesMetadataYml, ActionTypes()).let {
-        if (fromFallbackVersion) it.copy(fromFallbackVersion = true) else it
-    }
+    return yaml.decodeFromStringOrDefaultIfEmpty(typesMetadataYml, ActionTypes())
 }
 
 internal fun ActionTypes.toTypesMap(): Map<String, Typing> =

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithNoInputsFromFallbackVersion.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithNoInputsFromFallbackVersion.kt
@@ -1,0 +1,53 @@
+// This file was generated using action-binding-generator. Don't change it by hand, otherwise your
+// changes will be overwritten with the next binding code regeneration.
+// See https://github.com/typesafegithub/github-workflows-kt for more info.
+@file:Suppress(
+    "DataClassPrivateConstructor",
+    "UNUSED_PARAMETER",
+)
+
+package io.github.typesafegithub.workflows.actions.johnsmith
+
+import io.github.typesafegithub.workflows.domain.actions.Action
+import io.github.typesafegithub.workflows.domain.actions.RegularAction
+import java.util.LinkedHashMap
+import kotlin.Deprecated
+import kotlin.ExposedCopyVisibility
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+
+/**
+ * Action: Action With No Inputs From Fallback Version
+ *
+ * Description
+ *
+ * [Action on GitHub](https://github.com/john-smith/action-with-no-inputs-from-fallback-version)
+ *
+ * @param _customInputs Type-unsafe map where you can put any inputs that are not yet supported by the binding
+ * @param _customVersion Allows overriding action's version, for example to use a specific minor version, or a newer version that the binding doesn't yet know about
+ */
+@Deprecated("These typings were create from a fallback version in https://github.com/typesafegithub/github-actions-typing-catalog, as soon as typings for this version are added, there could be breaking changes, and you need to delete these typings from your local Maven cache typically found in ~/.m2/repository/ to get the updated typing. Consider contributing updated typings to the catalog before using this version.")
+@ExposedCopyVisibility
+public data class ActionWithNoInputsFromFallbackVersion private constructor(
+    /**
+     * Type-unsafe map where you can put any inputs that are not yet supported by the binding
+     */
+    public val _customInputs: Map<String, String> = mapOf(),
+    /**
+     * Allows overriding action's version, for example to use a specific minor version, or a newer version that the binding doesn't yet know about
+     */
+    public val _customVersion: String? = null,
+) : RegularAction<Action.Outputs>("john-smith", "action-with-no-inputs-from-fallback-version", _customVersion ?: "v3") {
+    public constructor(
+        vararg pleaseUseNamedArguments: Unit,
+        _customInputs: Map<String, String> = mapOf(),
+        _customVersion: String? = null,
+    ) : this(_customInputs = _customInputs, _customVersion = _customVersion)
+
+    @Suppress("SpreadOperator")
+    override fun toYamlArguments(): LinkedHashMap<String, String> = LinkedHashMap(_customInputs)
+
+    override fun buildOutputObject(stepId: String): Action.Outputs = Outputs(stepId)
+}

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithNoInputsFromFallbackVersion.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/bindingsfromunittests/ActionWithNoInputsFromFallbackVersion.kt
@@ -28,7 +28,7 @@ import kotlin.collections.Map
  * @param _customInputs Type-unsafe map where you can put any inputs that are not yet supported by the binding
  * @param _customVersion Allows overriding action's version, for example to use a specific minor version, or a newer version that the binding doesn't yet know about
  */
-@Deprecated("These typings were create from a fallback version in https://github.com/typesafegithub/github-actions-typing-catalog, as soon as typings for this version are added, there could be breaking changes, and you need to delete these typings from your local Maven cache typically found in ~/.m2/repository/ to get the updated typing. Consider contributing updated typings to the catalog before using this version.")
+@Deprecated("This typed binding was created from typings for an older version in https://github.com/typesafegithub/github-actions-typing-catalog. As soon as typings for the requested version are added, there could be breaking changes, and you need to delete these typings from your local Maven cache typically found in ~/.m2/repository/ to get the updated typing. In some cases, though, you may be lucky and things will work fine. To be on the safe side, consider contributing updated typings to the catalog before using this version, or even better: ask the action's owner to host the typings together with the action using https://github.com/typesafegithub/github-actions-typing.")
 @ExposedCopyVisibility
 public data class ActionWithNoInputsFromFallbackVersion private constructor(
     /**

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -287,6 +287,30 @@ class GenerationTest :
             binding.shouldContainAndMatchFile("ActionWithNoInputs.kt")
         }
 
+        test("action with no inputs from fallback version") {
+            // given
+            val actionManifestHasNoInputs = emptyMap<String, Input>()
+            val actionManifest =
+                Metadata(
+                    inputs = actionManifestHasNoInputs,
+                    name = "Action With No Inputs From Fallback Version",
+                    description = "Description",
+                )
+
+            val coords = ActionCoords("john-smith", "action-with-no-inputs-from-fallback-version", "v3")
+
+            // when
+            val binding =
+                coords.generateBinding(
+                    metadataRevision = NewestForVersion,
+                    metadata = actionManifest,
+                    inputTypings = ActionTypings(source = TYPING_CATALOG, fromFallbackVersion = true),
+                )
+
+            // then
+            binding.shouldContainAndMatchFile("ActionWithNoInputsFromFallbackVersion.kt")
+        }
+
         test("subaction") {
             // given
             val actionManifestHasNoInputs = emptyMap<String, Input>()

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -1,6 +1,7 @@
 package io.github.typesafegithub.workflows.actionbindinggenerator.generation
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionTypings
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestForVersion
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion.FULL
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion.MAJOR
@@ -151,7 +152,11 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                    inputTypings =
+                        ActionTypings(
+                            inputTypings = actionManifest.allInputsAsStrings(),
+                            source = ACTION,
+                        ),
                 )
 
             // then
@@ -201,7 +206,11 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                    inputTypings =
+                        ActionTypings(
+                            inputTypings = actionManifest.allInputsAsStrings(),
+                            source = ACTION,
+                        ),
                 )
 
             // then
@@ -218,9 +227,9 @@ class GenerationTest :
                     metadataRevision = NewestForVersion,
                     metadata = actionManifestWithAllTypesOfInputsAndSomeOutput,
                     inputTypings =
-                        Pair(
-                            typingsForAllTypesOfInputs,
-                            ACTION,
+                        ActionTypings(
+                            inputTypings = typingsForAllTypesOfInputs,
+                            source = ACTION,
                         ),
                 )
 
@@ -259,7 +268,11 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                    inputTypings =
+                        ActionTypings(
+                            inputTypings = actionManifest.allInputsAsStrings(),
+                            source = ACTION,
+                        ),
                 )
 
             // then
@@ -283,11 +296,35 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(emptyMap(), ACTION),
+                    inputTypings = ActionTypings(source = ACTION),
                 )
 
             // then
             binding.shouldContainAndMatchFile("ActionWithNoInputs.kt")
+        }
+
+        test("action with no inputs from fallback version") {
+            // given
+            val actionManifestHasNoInputs = emptyMap<String, Input>()
+            val actionManifest =
+                Metadata(
+                    inputs = actionManifestHasNoInputs,
+                    name = "Action With No Inputs From Fallback Version",
+                    description = "Description",
+                )
+
+            val coords = ActionCoords("john-smith", "action-with-no-inputs-from-fallback-version", "v3")
+
+            // when
+            val binding =
+                coords.generateBinding(
+                    metadataRevision = NewestForVersion,
+                    metadata = actionManifest,
+                    inputTypings = ActionTypings(source = TYPING_CATALOG, fromFallbackVersion = true),
+                )
+
+            // then
+            binding.shouldContainAndMatchFile("ActionWithNoInputsFromFallbackVersion.kt")
         }
 
         test("subaction") {
@@ -307,7 +344,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(emptyMap(), ACTION),
+                    inputTypings = ActionTypings(source = ACTION),
                 )
 
             // then
@@ -345,7 +382,11 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                    inputTypings =
+                        ActionTypings(
+                            inputTypings = actionManifest.allInputsAsStrings(),
+                            source = ACTION,
+                        ),
                 )
 
             // then
@@ -385,13 +426,14 @@ class GenerationTest :
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
                     inputTypings =
-                        Pair(
-                            mapOf(
-                                "foo-one" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
-                                "foo-two" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
-                                "foo-three" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
-                            ),
-                            ACTION,
+                        ActionTypings(
+                            inputTypings =
+                                mapOf(
+                                    "foo-one" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
+                                    "foo-two" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
+                                    "foo-three" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
+                                ),
+                            source = ACTION,
                         ),
                 )
 
@@ -424,7 +466,11 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                    inputTypings =
+                        ActionTypings(
+                            inputTypings = actionManifest.allInputsAsStrings(),
+                            source = ACTION,
+                        ),
                 )
 
             // then
@@ -458,7 +504,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(emptyMap(), null),
+                    inputTypings = ActionTypings(source = null),
                 )
 
             // then
@@ -497,7 +543,11 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(mapOf("foo" to IntegerTyping), TYPING_CATALOG),
+                    inputTypings =
+                        ActionTypings(
+                            mapOf(pair = "foo" to IntegerTyping),
+                            TYPING_CATALOG,
+                        ),
                 )
 
             // then
@@ -524,7 +574,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(emptyMap(), ACTION),
+                    inputTypings = ActionTypings(source = ACTION),
                 )
 
             // then
@@ -551,7 +601,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(emptyMap(), ACTION),
+                    inputTypings = ActionTypings(source = ACTION),
                 )
 
             // then

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
@@ -2,6 +2,7 @@ package io.github.typesafegithub.workflows.actionbindinggenerator.typing
 
 import com.charleskorn.kaml.ForbiddenAnchorOrAliasException
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionTypings
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.CommitHash
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion.FULL
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
@@ -22,7 +23,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe emptyMap()
+            types.inputTypings shouldBe emptyMap()
         }
 
         test("copes with comment-only typing") {
@@ -34,7 +35,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe emptyMap()
+            types.inputTypings shouldBe emptyMap()
         }
 
         test("copes with empty inputs") {
@@ -46,7 +47,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe emptyMap()
+            types.inputTypings shouldBe emptyMap()
         }
 
         test("copes with empty outputs") {
@@ -58,7 +59,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe emptyMap()
+            types.inputTypings shouldBe emptyMap()
         }
 
         test("copes with empty inputs and outputs") {
@@ -74,7 +75,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe emptyMap()
+            types.inputTypings shouldBe emptyMap()
         }
 
         test("parses all allowed elements of valid typing") {
@@ -120,7 +121,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe
+            types.inputTypings shouldBe
                 mapOf(
                     "name" to StringTyping,
                     "verbose" to BooleanTyping,
@@ -180,7 +181,11 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("hosted-by-action-yml" to StringTyping), TypingActualSource.ACTION)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("hosted-by-action-yml" to StringTyping),
+                        source = TypingActualSource.ACTION,
+                    )
             }
 
             test("only hosted by the subaction (.yml)") {
@@ -200,7 +205,11 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("hosted-by-action-yml" to StringTyping), TypingActualSource.ACTION)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("hosted-by-action-yml" to StringTyping),
+                        source = TypingActualSource.ACTION,
+                    )
             }
 
             test("only hosted by the action (.yaml)") {
@@ -217,7 +226,11 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("hosted-by-action-yaml" to StringTyping), TypingActualSource.ACTION)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("hosted-by-action-yaml" to StringTyping),
+                        source = TypingActualSource.ACTION,
+                    )
             }
 
             test("only hosted by the subaction (.yaml)") {
@@ -237,7 +250,11 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("hosted-by-action-yaml" to StringTyping), TypingActualSource.ACTION)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("hosted-by-action-yaml" to StringTyping),
+                        source = TypingActualSource.ACTION,
+                    )
             }
 
             test("only hosted by the action, both extensions") {
@@ -255,7 +272,11 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("hosted-by-action-yml" to StringTyping), TypingActualSource.ACTION)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("hosted-by-action-yml" to StringTyping),
+                        source = TypingActualSource.ACTION,
+                    )
             }
 
             test("only hosted by the subaction, both extensions") {
@@ -279,7 +300,11 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("hosted-by-action-yml" to StringTyping), TypingActualSource.ACTION)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("hosted-by-action-yml" to StringTyping),
+                        source = TypingActualSource.ACTION,
+                    )
             }
 
             test("only stored in typing catalog") {
@@ -300,7 +325,11 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("stored-in-typing-catalog" to StringTyping), TypingActualSource.TYPING_CATALOG)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("stored-in-typing-catalog" to StringTyping),
+                        source = TypingActualSource.TYPING_CATALOG,
+                    )
             }
 
             test("only stored in typing catalog for subaction") {
@@ -321,7 +350,11 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("stored-in-typing-catalog" to StringTyping), TypingActualSource.TYPING_CATALOG)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("stored-in-typing-catalog" to StringTyping),
+                        source = TypingActualSource.TYPING_CATALOG,
+                    )
             }
 
             test("hosted by action and stored in typing catalog") {
@@ -347,7 +380,11 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("hosted-by-action-yml" to StringTyping), TypingActualSource.ACTION)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("hosted-by-action-yml" to StringTyping),
+                        source = TypingActualSource.ACTION,
+                    )
             }
 
             test("hosted by subaction and stored in typing catalog") {
@@ -373,7 +410,11 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("hosted-by-action-yml" to StringTyping), TypingActualSource.ACTION)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("hosted-by-action-yml" to StringTyping),
+                        source = TypingActualSource.ACTION,
+                    )
             }
 
             test("only stored in typing catalog for older version") {
@@ -399,7 +440,12 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("stored-in-typing-catalog-for-older-version" to StringTyping), TypingActualSource.TYPING_CATALOG)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("stored-in-typing-catalog-for-older-version" to StringTyping),
+                        source = TypingActualSource.TYPING_CATALOG,
+                        fromFallbackVersion = true,
+                    )
             }
 
             test("only stored in typing catalog for older version of subaction") {
@@ -425,7 +471,12 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(mapOf("stored-in-typing-catalog-for-older-version" to StringTyping), TypingActualSource.TYPING_CATALOG)
+                types shouldBe
+                    ActionTypings(
+                        inputTypings = mapOf("stored-in-typing-catalog-for-older-version" to StringTyping),
+                        source = TypingActualSource.TYPING_CATALOG,
+                        fromFallbackVersion = true,
+                    )
             }
 
             test("metadata available but no version available") {
@@ -446,7 +497,7 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(emptyMap(), null)
+                types shouldBe ActionTypings()
             }
 
             test("no typings at all") {
@@ -458,7 +509,7 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(emptyMap(), null)
+                types shouldBe ActionTypings()
             }
         }
 
@@ -503,13 +554,14 @@ class TypesProvidingTest :
 
                 // Then
                 types shouldBe
-                    Pair(
-                        mapOf(
-                            "granted-scopes" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
-                            "granted-scopes2" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
-                            "granted-scopes3" to ListOfTypings("""\n""", EnumTyping("GrantedScopes", listOf("read", "write"))),
-                        ),
-                        TypingActualSource.ACTION,
+                    ActionTypings(
+                        inputTypings =
+                            mapOf(
+                                "granted-scopes" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
+                                "granted-scopes2" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
+                                "granted-scopes3" to ListOfTypings("""\n""", EnumTyping("GrantedScopes", listOf("read", "write"))),
+                            ),
+                        source = TypingActualSource.ACTION,
                     )
             }
 
@@ -532,13 +584,14 @@ class TypesProvidingTest :
 
                 // Then
                 types shouldBe
-                    Pair(
-                        mapOf(
-                            "granted-scopes" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
-                            "granted-scopes2" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
-                            "granted-scopes3" to ListOfTypings("""\n""", EnumTyping("GrantedScopes", listOf("read", "write"))),
-                        ),
-                        TypingActualSource.TYPING_CATALOG,
+                    ActionTypings(
+                        inputTypings =
+                            mapOf(
+                                "granted-scopes" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
+                                "granted-scopes2" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
+                                "granted-scopes3" to ListOfTypings("""\n""", EnumTyping("GrantedScopes", listOf("read", "write"))),
+                            ),
+                        source = TypingActualSource.TYPING_CATALOG,
                     )
             }
 
@@ -566,13 +619,15 @@ class TypesProvidingTest :
 
                 // Then
                 types shouldBe
-                    Pair(
-                        mapOf(
-                            "granted-scopes" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
-                            "granted-scopes2" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
-                            "granted-scopes3" to ListOfTypings("""\n""", EnumTyping("GrantedScopes", listOf("read", "write"))),
-                        ),
-                        TypingActualSource.TYPING_CATALOG,
+                    ActionTypings(
+                        inputTypings =
+                            mapOf(
+                                "granted-scopes" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
+                                "granted-scopes2" to ListOfTypings(",", EnumTyping("GrantedScopes", listOf("read", "write"))),
+                                "granted-scopes3" to ListOfTypings("""\n""", EnumTyping("GrantedScopes", listOf("read", "write"))),
+                            ),
+                        source = TypingActualSource.TYPING_CATALOG,
+                        fromFallbackVersion = true,
                     )
             }
 
@@ -632,6 +687,6 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
             // Then
-            types shouldBe Pair(emptyMap(), null)
+            types shouldBe ActionTypings()
         }
     })


### PR DESCRIPTION
This should hopefully improve on https://slack-chats.kotlinlang.org/t/28511490/hi-i-might-have-a-similar-problem-as-leonardo-had-https-kotl#8c8c2a6c-f008-4184-a8b7-25620530191d, at least notifying users by a deprecation note that fallback typings are used and that they might have to clear the cache to get updated typings and also nudge them to update the catalog typings.