### PR TITLE
ci: print server logs after server tests

### DIFF
--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -148,6 +148,12 @@ workflow(
             name = "Fetch maven-metadata.xml for nested action",
             command = "curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep '<version>v4</version>'",
         )
+
+        run(
+            name = "Print server logs",
+            command = "cat jit-binding-server/logs/server.log",
+            condition = expr { always() }
+        )
     }
 
     job(

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -118,6 +118,10 @@ jobs:
     - id: 'step-16'
       name: 'Fetch maven-metadata.xml for nested action'
       run: 'curl --fail http://localhost:8080/actions/cache__save/maven-metadata.xml | grep ''<version>v4</version>'''
+    - id: 'step-17'
+      name: 'Print server logs'
+      run: 'cat jit-binding-server/logs/server.log'
+      if: '${{ always() }}'
   deploy:
     name: 'Deploy to DockerHub'
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
I noticed some flakiness in the tests, in fetching bindings. Let's add some basic observability to enable troubleshooting.