### PR TITLE
refactor(abg): create custom type for typings and source pair

### DIFF
--- a/action-binding-generator/api/action-binding-generator.api
+++ b/action-binding-generator/api/action-binding-generator.api
@@ -26,6 +26,21 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/dom
 	public static final fun isTopLevel (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;)Z
 }
 
+public final class io/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;)V
+	public synthetic fun <init> (Ljava/util/Map;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;
+	public final fun copy (Ljava/util/Map;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;)Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;Ljava/util/Map;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInputTypings ()Ljava/util/Map;
+	public final fun getSource ()Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/TypingActualSource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/domain/CommitHash : io/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -85,8 +100,8 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/gen
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationKt {
-	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;)Ljava/util/List;
-	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lkotlin/Pair;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;)Ljava/util/List;
+	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;ILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/metadata/Input {

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings.kt
@@ -1,0 +1,8 @@
+package io.github.typesafegithub.workflows.actionbindinggenerator.domain
+
+import io.github.typesafegithub.workflows.actionbindinggenerator.typing.Typing
+
+public data class ActionTypings(
+    val inputTypings: Map<String, Typing> = emptyMap(),
+    val source: TypingActualSource? = null,
+)

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
@@ -16,6 +16,7 @@ import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.buildCodeBlock
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionTypings
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.MetadataRevision
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion.FULL
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion.MAJOR
@@ -63,7 +64,7 @@ private object Properties {
 public fun ActionCoords.generateBinding(
     metadataRevision: MetadataRevision,
     metadata: Metadata? = null,
-    inputTypings: Pair<Map<String, Typing>, TypingActualSource?>? = null,
+    inputTypings: ActionTypings? = null,
 ): List<ActionBinding> {
     val metadataResolved = metadata ?: this.fetchMetadata(metadataRevision) ?: return emptyList()
     val metadataProcessed = metadataResolved.removeDeprecatedInputsIfNameClash()
@@ -81,7 +82,7 @@ public fun ActionCoords.generateBinding(
             emptyMap(),
             classNameUntyped,
             untypedClass = true,
-            replaceWith = inputTypingsResolved.second?.let { CodeBlock.of("ReplaceWith(%S)", className) },
+            replaceWith = inputTypingsResolved.source?.let { CodeBlock.of("ReplaceWith(%S)", className) },
         )
 
     return listOfNotNull(
@@ -92,12 +93,12 @@ public fun ActionCoords.generateBinding(
             packageName = packageName,
             typingActualSource = null,
         ),
-        inputTypingsResolved.second?.let {
+        inputTypingsResolved.source?.let {
             val actionBindingSourceCode =
                 generateActionBindingSourceCode(
                     metadata = metadataProcessed,
                     coords = this,
-                    inputTypings = inputTypingsResolved.first,
+                    inputTypings = inputTypingsResolved.inputTypings,
                     className = className,
                 )
             ActionBinding(

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
@@ -5,6 +5,7 @@ import com.charleskorn.kaml.EmptyYamlDocumentException
 import com.charleskorn.kaml.Yaml
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionTypings
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.CommitHash
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.MetadataRevision
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestForVersion
@@ -24,12 +25,17 @@ private val logger = logger { }
 internal fun ActionCoords.provideTypes(
     metadataRevision: MetadataRevision,
     fetchUri: (URI) -> String = ::fetchUri,
-): Pair<Map<String, Typing>, TypingActualSource?> =
+): ActionTypings =
     (
         this.fetchTypingMetadata(metadataRevision, fetchUri)
             ?: this.toMajorVersion().fetchFromTypingsFromCatalog(fetchUri)
-    )?.let { Pair(it.first.toTypesMap(), it.second) }
-        ?: Pair(emptyMap(), null)
+    )?.let { (typings, typingActualSource) ->
+        ActionTypings(
+            inputTypings = typings.toTypesMap(),
+            source = typingActualSource,
+        )
+    }
+        ?: ActionTypings()
 
 private fun ActionCoords.actionTypesYmlUrl(gitRef: String) =
     "https://raw.githubusercontent.com/$owner/$name/$gitRef$subName/action-types.yml"

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationTest.kt
@@ -1,6 +1,7 @@
 package io.github.typesafegithub.workflows.actionbindinggenerator.generation
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionTypings
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestForVersion
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion.FULL
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion.MAJOR
@@ -151,7 +152,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                    inputTypings = ActionTypings(inputTypings = actionManifest.allInputsAsStrings(), source = ACTION),
                 )
 
             // then
@@ -201,7 +202,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                    inputTypings = ActionTypings(inputTypings = actionManifest.allInputsAsStrings(), source = ACTION),
                 )
 
             // then
@@ -217,11 +218,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifestWithAllTypesOfInputsAndSomeOutput,
-                    inputTypings =
-                        Pair(
-                            typingsForAllTypesOfInputs,
-                            ACTION,
-                        ),
+                    inputTypings = ActionTypings(inputTypings = typingsForAllTypesOfInputs, source = ACTION),
                 )
 
             // then
@@ -259,7 +256,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                    inputTypings = ActionTypings(inputTypings = actionManifest.allInputsAsStrings(), source = ACTION),
                 )
 
             // then
@@ -283,7 +280,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(emptyMap(), ACTION),
+                    inputTypings = ActionTypings(inputTypings = emptyMap(), source = ACTION),
                 )
 
             // then
@@ -307,7 +304,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(emptyMap(), ACTION),
+                    inputTypings = ActionTypings(inputTypings = emptyMap(), source = ACTION),
                 )
 
             // then
@@ -345,7 +342,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                    inputTypings = ActionTypings(inputTypings = actionManifest.allInputsAsStrings(), source = ACTION),
                 )
 
             // then
@@ -385,13 +382,14 @@ class GenerationTest :
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
                     inputTypings =
-                        Pair(
-                            mapOf(
-                                "foo-one" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
-                                "foo-two" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
-                                "foo-three" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
-                            ),
-                            ACTION,
+                        ActionTypings(
+                            inputTypings =
+                                mapOf(
+                                    "foo-one" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
+                                    "foo-two" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
+                                    "foo-three" to IntegerWithSpecialValueTyping("Foo", mapOf("Special1" to 3)),
+                                ),
+                            source = ACTION,
                         ),
                 )
 
@@ -424,7 +422,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(actionManifest.allInputsAsStrings(), ACTION),
+                    inputTypings = ActionTypings(inputTypings = actionManifest.allInputsAsStrings(), source = ACTION),
                 )
 
             // then
@@ -458,7 +456,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(emptyMap(), null),
+                    inputTypings = ActionTypings(inputTypings = emptyMap(), source = null),
                 )
 
             // then
@@ -497,7 +495,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(mapOf("foo" to IntegerTyping), TYPING_CATALOG),
+                    inputTypings = ActionTypings(inputTypings = mapOf("foo" to IntegerTyping), source = TYPING_CATALOG),
                 )
 
             // then
@@ -524,7 +522,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(emptyMap(), ACTION),
+                    inputTypings = ActionTypings(inputTypings = emptyMap(), source = ACTION),
                 )
 
             // then
@@ -551,7 +549,7 @@ class GenerationTest :
                 coords.generateBinding(
                     metadataRevision = NewestForVersion,
                     metadata = actionManifest,
-                    inputTypings = Pair(emptyMap(), ACTION),
+                    inputTypings = ActionTypings(inputTypings = emptyMap(), source = ACTION),
                 )
 
             // then

--- a/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
+++ b/action-binding-generator/src/test/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProvidingTest.kt
@@ -2,6 +2,7 @@ package io.github.typesafegithub.workflows.actionbindinggenerator.typing
 
 import com.charleskorn.kaml.ForbiddenAnchorOrAliasException
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionTypings
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.CommitHash
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion.FULL
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingActualSource
@@ -22,7 +23,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe emptyMap()
+            types.inputTypings shouldBe emptyMap()
         }
 
         test("copes with comment-only typing") {
@@ -34,7 +35,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe emptyMap()
+            types.inputTypings shouldBe emptyMap()
         }
 
         test("copes with empty inputs") {
@@ -46,7 +47,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe emptyMap()
+            types.inputTypings shouldBe emptyMap()
         }
 
         test("copes with empty outputs") {
@@ -58,7 +59,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe emptyMap()
+            types.inputTypings shouldBe emptyMap()
         }
 
         test("copes with empty inputs and outputs") {
@@ -74,7 +75,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe emptyMap()
+            types.inputTypings shouldBe emptyMap()
         }
 
         test("parses all allowed elements of valid typing") {
@@ -120,7 +121,7 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), { actionTypesYml })
 
             // Then
-            types.first shouldBe
+            types.inputTypings shouldBe
                 mapOf(
                     "name" to StringTyping,
                     "verbose" to BooleanTyping,
@@ -446,7 +447,7 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(emptyMap(), null)
+                types shouldBe ActionTypings(inputTypings = emptyMap(), source = null)
             }
 
             test("no typings at all") {
@@ -458,7 +459,7 @@ class TypesProvidingTest :
                 val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
                 // Then
-                types shouldBe Pair(emptyMap(), null)
+                types shouldBe ActionTypings(inputTypings = emptyMap(), source = null)
             }
         }
 
@@ -632,6 +633,6 @@ class TypesProvidingTest :
             val types = actionCoord.provideTypes(metadataRevision = CommitHash("some-hash"), fetchUri = fetchUri)
 
             // Then
-            types shouldBe Pair(emptyMap(), null)
+            types shouldBe ActionTypings(inputTypings = emptyMap(), source = null)
         }
     })


### PR DESCRIPTION
On its own, it improves readability. Also, in https://github.com/typesafegithub/github-workflows-kt/pull/1967 it's going to be extended by one field.