### PR TITLE
chore(deps): use the same Kotlin version for Gradle

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `kotlin-dsl`
-    kotlin("jvm") version embeddedKotlinVersion
+    kotlin("jvm") version "2.1.21"
 }
 
 dependencies {


### PR DESCRIPTION
Gradle usually lags behind newest Kotlin version, more or less. Let's try tracking the newest Kotlin version used for the Kotlin DSL in Gradle.