### PR TITLE
chore: migrate off of deprecated kotlinOptions API

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm-server.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm-server.gradle.kts
@@ -1,5 +1,6 @@
 package buildsrc.convention
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -36,13 +37,11 @@ fun JavaToolchainSpec.requiredJdkVersion() {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "17"
-
-        allWarningsAsErrors = true
-    }
-
     compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+
+        allWarningsAsErrors.set(true)
+
         freeCompilerArgs.addAll(
             "-opt-in=kotlin.ExperimentalStdlibApi",
             "-opt-in=kotlin.time.ExperimentalTime",

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -1,5 +1,6 @@
 package buildsrc.convention
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -36,14 +37,12 @@ fun JavaToolchainSpec.requiredJdkVersion() {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        // It's available without extra setup on GitHub Actions runners.
-        jvmTarget = "11"
-
-        allWarningsAsErrors = true
-    }
-
     compilerOptions {
+        // It's available without extra setup on GitHub Actions runners.
+        jvmTarget.set(JvmTarget.JVM_11)
+
+        allWarningsAsErrors.set(true)
+
         freeCompilerArgs.addAll(
             "-opt-in=kotlin.ExperimentalStdlibApi",
             "-opt-in=kotlin.time.ExperimentalTime",


### PR DESCRIPTION
Necessary because when updating to Kotlin 2.2.0, the build starts failing.