### PR TITLE
feat: produce bindings with 2.0 Kotlin target

### DIFF
--- a/.github/workflows/bindings-server.main.kts
+++ b/.github/workflows/bindings-server.main.kts
@@ -108,8 +108,8 @@ workflow(
 
         // There should be a difference of one (mostly minor) version between these two,
         // to be able to see the newest non-working and oldest working version.
-        val newestNotCompatibleVersion = "2.0.0"
-        val oldestCompatibleVersion = "2.1.0"
+        val newestNotCompatibleVersion = "1.9.0"
+        val oldestCompatibleVersion = "2.0.0"
 
         runWithSpecificKotlinVersion(
             kotlinVersion = newestNotCompatibleVersion,

--- a/.github/workflows/bindings-server.yaml
+++ b/.github/workflows/bindings-server.yaml
@@ -81,29 +81,29 @@ jobs:
         mv .github/workflows/test-served-bindings-depend-on-library.main.do-not-compile.kts .github/workflows/test-served-bindings-depend-on-library.main.kts
         .github/workflows/test-served-bindings-depend-on-library.main.kts
     - id: 'step-8'
-      name: 'Install Kotlin 2.0.0'
+      name: 'Install Kotlin 1.9.0'
       uses: 'fwilhe2/setup-kotlin@v1'
       with:
-        version: '2.0.0'
+        version: '1.9.0'
     - id: 'step-9'
       name: 'Clean Maven Local to fetch required POMs again'
       run: 'rm -rf ~/.m2/repository/'
     - id: 'step-10'
-      name: 'Execute the script using the bindings from the server, using older Kotlin (2.0.0) as consumer'
+      name: 'Execute the script using the bindings from the server, using older Kotlin (1.9.0) as consumer'
       run: |2-
                         cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts
                         (.github/workflows/test-script-consuming-jit-bindings-too-old-kotlin.main.kts || true) >> output.txt 2>&1
         grep "was compiled with an incompatible version of Kotlin" output.txt
     - id: 'step-11'
-      name: 'Install Kotlin 2.1.0'
+      name: 'Install Kotlin 2.0.0'
       uses: 'fwilhe2/setup-kotlin@v1'
       with:
-        version: '2.1.0'
+        version: '2.0.0'
     - id: 'step-12'
       name: 'Clean Maven Local to fetch required POMs again'
       run: 'rm -rf ~/.m2/repository/'
     - id: 'step-13'
-      name: 'Execute the script using the bindings from the server, using older Kotlin (2.1.0) as consumer'
+      name: 'Execute the script using the bindings from the server, using older Kotlin (2.0.0) as consumer'
       run: |-
         cp .github/workflows/test-script-consuming-jit-bindings.main.kts .github/workflows/test-script-consuming-jit-bindings-older-kotlin.main.kts
         .github/workflows/test-script-consuming-jit-bindings-older-kotlin.main.kts

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/JarBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/JarBuilding.kt
@@ -59,6 +59,8 @@ internal fun ActionCoords.buildJars(): Jars? {
     )
 }
 
+private const val TARGET_KOTLIN_VERSION = "2.0"
+
 private fun compileBinding(sourceFilePaths: List<Path>): Path {
     val compilationOutput = createTempDirectory(prefix = "gwkt-classes_")
 
@@ -67,6 +69,8 @@ private fun compileBinding(sourceFilePaths: List<Path>): Path {
             destination = compilationOutput.toString()
             classpath = System.getProperty("java.class.path")
             freeArgs = sourceFilePaths.map { it.toString() }
+            languageVersion = TARGET_KOTLIN_VERSION
+            apiVersion = TARGET_KOTLIN_VERSION
             noStdlib = true
             noReflect = true
             includeRuntime = false


### PR DESCRIPTION
Thanks to this, consumer that use older Kotlin version may use the bindings server. The oldest compatible version is 1.9.0.

Part of https://github.com/typesafegithub/github-workflows-kt/issues/1756.