### PR TITLE
fix: migrate to Central Portal for publishing Maven artifacts

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -68,6 +68,7 @@ workflow(
         id = "publish-snapshot",
         name = "Publish snapshot",
         runsOn = UbuntuLatest,
+        condition = expr { "${github.ref} == 'refs/heads/main'" },
         env = mapOf(
             "ORG_GRADLE_PROJECT_sonatypeUsername" to expr("secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME"),
             "ORG_GRADLE_PROJECT_sonatypePassword" to expr("secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD"),

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,6 +101,7 @@ jobs:
     env:
       ORG_GRADLE_PROJECT_sonatypeUsername: '${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}'
       ORG_GRADLE_PROJECT_sonatypePassword: '${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}'
+    if: '${{ github.ref == ''refs/heads/main'' }}'
     steps:
     - id: 'step-0'
       uses: 'actions/checkout@v4'


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/1953.

Followed https://central.sonatype.org/pages/ossrh-eol/#publishing-to-central-portal.