### PR TITLE
test: add tests asserting on Java bytecode version

### DIFF
--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/JavaBytecodeVersionTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/JavaBytecodeVersionTest.kt
@@ -1,0 +1,28 @@
+package io.github.typesafegithub.workflows
+
+import io.github.typesafegithub.workflows.domain.Workflow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.DataInputStream
+
+class JavaBytecodeVersionTest :
+    FunSpec(
+        {
+            test("library is built with desired Java bytecode version") {
+                Workflow::class.java.classLoader
+                    .getResourceAsStream(
+                        "io/github/typesafegithub/workflows/domain/Workflow.class",
+                    )!!
+                    .use { inputStream ->
+                        val dataInputStream = DataInputStream(inputStream)
+                        require(dataInputStream.readInt() == 0xCAFEBABE.toInt()) { "Invalid class header" }
+                        val minor = dataInputStream.readUnsignedShort()
+                        val major = dataInputStream.readUnsignedShort()
+
+                        // Corresponds to JDK 11
+                        major shouldBe 55
+                        minor shouldBe 0
+                    }
+            }
+        },
+    )


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/1699.

Useful to ensure that we don't accidentally produce JARs with different bytecode version.