### PR TITLE
chore(ci): do not treat warnings as errors in Kotlin scripts

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -119,7 +119,7 @@ workflow(
                 fi
 
                 echo "Compiling ${'$'}file..."
-                kotlinc -Werror -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "${'$'}file"
+                kotlinc -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "${'$'}file"
             done
             """.trimIndent()
         )

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -170,7 +170,7 @@ jobs:
             fi
 
             echo "Compiling $file..."
-            kotlinc -Werror -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "$file"
+            kotlinc -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "$file"
         done
   workflows_consistency_check:
     name: 'Run consistency check on all GitHub workflows'


### PR DESCRIPTION
Warnings often appear when actions do not have typings for a new major version. Let's be less strict here.