### PR TITLE
chore(abg): lift creation of default HTTP client to generateBindings fun

### DIFF
--- a/action-binding-generator/api/action-binding-generator.api
+++ b/action-binding-generator/api/action-binding-generator.api
@@ -102,8 +102,8 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/gen
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/generation/GenerationKt {
-	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun generateBinding (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;Lio/ktor/client/HttpClient;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun generateBinding$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/github/typesafegithub/workflows/actionbindinggenerator/metadata/Metadata;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionTypings;Lio/ktor/client/HttpClient;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/metadata/Input {
@@ -177,7 +177,6 @@ public final class io/github/typesafegithub/workflows/actionbindinggenerator/met
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/metadata/MetadataReadingKt {
 	public static final fun fetchMetadata (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/ktor/client/HttpClient;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun fetchMetadata$default (Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/ActionCoords;Lio/github/typesafegithub/workflows/actionbindinggenerator/domain/MetadataRevision;Lio/ktor/client/HttpClient;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/github/typesafegithub/workflows/actionbindinggenerator/metadata/Output {

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/generation/Generation.kt
@@ -40,6 +40,8 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.typing.provideT
 import io.github.typesafegithub.workflows.actionbindinggenerator.utils.removeTrailingWhitespacesForEachLine
 import io.github.typesafegithub.workflows.actionbindinggenerator.utils.toCamelCase
 import io.github.typesafegithub.workflows.actionbindinggenerator.utils.toKotlinPackageName
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
 
 public data class ActionBinding(
     val kotlinCode: String,
@@ -69,11 +71,13 @@ public suspend fun ActionCoords.generateBinding(
     metadataRevision: MetadataRevision,
     metadata: Metadata? = null,
     inputTypings: ActionTypings? = null,
+    httpClient: HttpClient = HttpClient(CIO),
 ): List<ActionBinding> {
-    val metadataResolved = metadata ?: this.fetchMetadata(metadataRevision) ?: return emptyList()
+    val metadataResolved =
+        metadata ?: this.fetchMetadata(metadataRevision, httpClient = httpClient) ?: return emptyList()
     val metadataProcessed = metadataResolved.removeDeprecatedInputsIfNameClash()
 
-    val inputTypingsResolved = inputTypings ?: this.provideTypes(metadataRevision)
+    val inputTypingsResolved = inputTypings ?: this.provideTypes(metadataRevision, httpClient = httpClient)
 
     val packageName = owner.toKotlinPackageName()
     val className = this.buildActionClassName()

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/metadata/MetadataReading.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/metadata/MetadataReading.kt
@@ -8,7 +8,6 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.Metadata
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.NewestForVersion
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.subName
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
@@ -49,11 +48,9 @@ private fun ActionCoords.actionYmlUrl(gitRef: String) =
 private fun ActionCoords.actionYamlUrl(gitRef: String) =
     "https://raw.githubusercontent.com/$owner/$name/$gitRef$subName/action.yaml"
 
-private val defaultHttpClient = HttpClient(CIO)
-
 public suspend fun ActionCoords.fetchMetadata(
     metadataRevision: MetadataRevision,
-    httpClient: HttpClient = defaultHttpClient,
+    httpClient: HttpClient,
 ): Metadata? {
     val gitRef =
         when (metadataRevision) {

--- a/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
+++ b/action-binding-generator/src/main/kotlin/io/github/typesafegithub/workflows/actionbindinggenerator/typing/TypesProviding.kt
@@ -15,7 +15,6 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.TypingAc
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.subName
 import io.github.typesafegithub.workflows.actionbindinggenerator.utils.toPascalCase
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
@@ -24,11 +23,10 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 
 private val logger = logger { }
-private val defaultHttpClient = HttpClient(CIO)
 
 internal suspend fun ActionCoords.provideTypes(
     metadataRevision: MetadataRevision,
-    httpClient: HttpClient = defaultHttpClient,
+    httpClient: HttpClient,
 ): ActionTypings =
     (
         this.fetchTypingMetadata(metadataRevision, httpClient)

--- a/jit-binding-server/build.gradle.kts
+++ b/jit-binding-server/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation("io.ktor:ktor-server-call-logging")
     implementation("io.ktor:ktor-server-call-id")
     implementation("io.ktor:ktor-server-metrics-micrometer")
+    implementation("io.ktor:ktor-client-core")
+    implementation("io.ktor:ktor-client-cio")
     implementation("io.micrometer:micrometer-registry-prometheus:1.15.5")
 
     implementation("com.sksamuel.aedile:aedile-core:3.0.1")


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/2160.

I'd like to intercept calls to GitHub on the bindings server level, and for this I'd like to use [HttpSend ktor plugn](https://ktor.io/docs/client-http-send.html). To use it, I need to inject the client augmented with this, and I want to do it from the bindings server.