### PR TITLE
chore(server): count calls to GitHub's API as metric

### DIFF
--- a/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
+++ b/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
@@ -30,7 +30,7 @@ class ArtifactRoutesTest :
                                 )
                             },
                             // Irrelevant for these tests.
-                            buildPackageArtifacts = { _, _, _ -> emptyMap() },
+                            buildPackageArtifacts = { _, _, _, _ -> emptyMap() },
                             getGithubAuthToken = { "" },
                         )
                     }
@@ -51,7 +51,7 @@ class ArtifactRoutesTest :
                         appModule(
                             buildVersionArtifacts = { _, _ -> null },
                             // Irrelevant for these tests.
-                            buildPackageArtifacts = { _, _, _ -> emptyMap() },
+                            buildPackageArtifacts = { _, _, _, _ -> emptyMap() },
                             getGithubAuthToken = { "" },
                         )
                     }
@@ -71,7 +71,7 @@ class ArtifactRoutesTest :
                         appModule(
                             buildVersionArtifacts = { _, _ -> error("An internal error occurred!") },
                             // Irrelevant for these tests.
-                            buildPackageArtifacts = { _, _, _ -> emptyMap() },
+                            buildPackageArtifacts = { _, _, _, _ -> emptyMap() },
                             getGithubAuthToken = { "" },
                         )
                     }
@@ -98,7 +98,7 @@ class ArtifactRoutesTest :
                         appModule(
                             buildVersionArtifacts = mockBuildVersionArtifacts,
                             // Irrelevant for these tests.
-                            buildPackageArtifacts = { _, _, _ -> emptyMap() },
+                            buildPackageArtifacts = { _, _, _, _ -> emptyMap() },
                             getGithubAuthToken = { "" },
                         )
                     }

--- a/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutesTest.kt
+++ b/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutesTest.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
+import io.micrometer.core.instrument.MeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -20,7 +21,7 @@ class MetadataRoutesTest :
                     // Given
                     application {
                         appModule(
-                            buildPackageArtifacts = { _, _, _ ->
+                            buildPackageArtifacts = { _, _, _, _ ->
                                 mapOf("maven-metadata.xml" to "Some XML contents")
                             },
                             getGithubAuthToken = { "some-token" },
@@ -48,7 +49,7 @@ class MetadataRoutesTest :
                     // Given
                     application {
                         appModule(
-                            buildPackageArtifacts = { _, _, _ ->
+                            buildPackageArtifacts = { _, _, _, _ ->
                                 emptyMap()
                             },
                             getGithubAuthToken = { "some-token" },
@@ -75,7 +76,7 @@ class MetadataRoutesTest :
                     // Given
                     application {
                         appModule(
-                            buildPackageArtifacts = { _, _, _ ->
+                            buildPackageArtifacts = { _, _, _, _ ->
                                 error("An internal error occurred!")
                             },
                             getGithubAuthToken = { "some-token" },
@@ -106,9 +107,10 @@ class MetadataRoutesTest :
                                 ActionCoords,
                                 String,
                                 (Collection<ActionCoords>) -> Unit,
+                                MeterRegistry?,
                             ) -> Map<String, String>,
                         >()
-                    every { mockBuildPackageArtifacts(any(), any(), any()) } throws
+                    every { mockBuildPackageArtifacts(any(), any(), any(), any()) } throws
                         Exception("An internal error occurred!") andThen
                         mapOf("maven-metadata.xml" to "Some XML contents")
                     application {
@@ -135,7 +137,7 @@ class MetadataRoutesTest :
                     // Then
                     response2.status shouldBe HttpStatusCode.OK
 
-                    verify(exactly = 2) { mockBuildPackageArtifacts(any(), any(), any()) }
+                    verify(exactly = 2) { mockBuildPackageArtifacts(any(), any(), any(), any()) }
                 }
             }
         }

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuilding.kt
@@ -7,21 +7,24 @@ import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCo
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.SignificantVersion.FULL
 import io.github.typesafegithub.workflows.shared.internal.fetchAvailableVersions
 import io.github.typesafegithub.workflows.shared.internal.model.Version
+import io.micrometer.core.instrument.MeterRegistry
 import java.time.format.DateTimeFormatter
 
 private val logger = logger { }
 
 internal suspend fun ActionCoords.buildMavenMetadataFile(
     githubAuthToken: String,
+    meterRegistry: MeterRegistry? = null,
     fetchAvailableVersions: suspend (
         owner: String,
         name: String,
         githubAuthToken: String?,
+        meterRegistry: MeterRegistry?,
     ) -> Either<String, List<Version>> = ::fetchAvailableVersions,
     prefetchBindingArtifacts: (Collection<ActionCoords>) -> Unit = {},
 ): String? {
     val availableVersions =
-        fetchAvailableVersions(owner, name, githubAuthToken)
+        fetchAvailableVersions(owner, name, githubAuthToken, meterRegistry)
             .getOrElse {
                 logger.error { it }
                 emptyList()

--- a/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PackageArtifactsBuilding.kt
+++ b/maven-binding-builder/src/main/kotlin/io/github/typesafegithub/workflows/mavenbinding/PackageArtifactsBuilding.kt
@@ -1,16 +1,19 @@
 package io.github.typesafegithub.workflows.mavenbinding
 
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
+import io.micrometer.core.instrument.MeterRegistry
 
 suspend fun buildPackageArtifacts(
     actionCoords: ActionCoords,
     githubAuthToken: String,
     prefetchBindingArtifacts: (Collection<ActionCoords>) -> Unit,
+    meterRegistry: MeterRegistry,
 ): Map<String, String> {
     val mavenMetadata =
         actionCoords.buildMavenMetadataFile(
             githubAuthToken = githubAuthToken,
             prefetchBindingArtifacts = prefetchBindingArtifacts,
+            meterRegistry = meterRegistry,
         ) ?: return emptyMap()
     return mapOf(
         "maven-metadata.xml" to mavenMetadata,

--- a/maven-binding-builder/src/test/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuildingTest.kt
+++ b/maven-binding-builder/src/test/kotlin/io/github/typesafegithub/workflows/mavenbinding/MavenMetadataBuildingTest.kt
@@ -9,6 +9,7 @@ import io.github.typesafegithub.workflows.shared.internal.model.Version
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import io.micrometer.core.instrument.MeterRegistry
 import java.time.ZonedDateTime
 
 class MavenMetadataBuildingTest :
@@ -26,7 +27,8 @@ class MavenMetadataBuildingTest :
                 String,
                 String,
                 String?,
-            ) -> Either<String, List<Version>> = { _, _, _ ->
+                MeterRegistry?,
+            ) -> Either<String, List<Version>> = { _, _, _, _ ->
                 listOf(
                     Version(version = "v3-beta", dateProvider = { ZonedDateTime.parse("2024-07-01T00:00:00Z") }),
                     Version(version = "v2", dateProvider = { ZonedDateTime.parse("2024-05-01T00:00:00Z") }),
@@ -70,7 +72,8 @@ class MavenMetadataBuildingTest :
                 String,
                 String,
                 String?,
-            ) -> Either<String, List<Version>> = { _, _, _ ->
+                MeterRegistry?,
+            ) -> Either<String, List<Version>> = { _, _, _, _ ->
                 listOf(
                     Version(version = "v1.1", dateProvider = { ZonedDateTime.parse("2024-03-07T00:00:00Z") }),
                     Version(version = "v1.1.0", dateProvider = { ZonedDateTime.parse("2024-03-07T00:00:00Z") }),
@@ -95,7 +98,8 @@ class MavenMetadataBuildingTest :
                 String,
                 String,
                 String?,
-            ) -> Either<String, List<Version>> = { _, _, _ ->
+                MeterRegistry?,
+            ) -> Either<String, List<Version>> = { _, _, _, _ ->
                 emptyList<Version>().right()
             }
 
@@ -115,7 +119,8 @@ class MavenMetadataBuildingTest :
                     String,
                     String,
                     String?,
-                ) -> Either<String, List<Version>> = { owner, name, _ ->
+                    MeterRegistry?,
+                ) -> Either<String, List<Version>> = { owner, name, _, _ ->
                     listOf(
                         Version(version = "v3-beta", dateProvider = { ZonedDateTime.parse("2024-07-01T00:00:00Z") }),
                         Version(version = "v2", dateProvider = { ZonedDateTime.parse("2024-05-01T00:00:00Z") }),

--- a/shared-internal/build.gradle.kts
+++ b/shared-internal/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     // we cannot use a BOM due to limitation in kotlin scripting when resolving the transitive KMM variant dependencies
     // note: see https://youtrack.jetbrains.com/issue/KT-67618
     api("io.ktor:ktor-client-core:3.3.3")
+    api("io.micrometer:micrometer-core:1.15.5")
     implementation("io.ktor:ktor-client-cio:3.3.3")
     implementation("io.ktor:ktor-client-content-negotiation:3.3.3")
     implementation("io.ktor:ktor-client-logging:3.3.3")


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/2160.

Thanks to this, we'll be able to assess the load on GitHub, and better understand if some server's instabilities are related to e.g. being throttled by GitHub.