### PR TITLE
feat(server): expose HEAD endpoint for metadata

### DIFF
--- a/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutes.kt
+++ b/jit-binding-server/src/main/kotlin/io/github/typesafegithub/workflows/jitbindingserver/MetadataRoutes.kt
@@ -4,10 +4,12 @@ import com.sksamuel.aedile.core.LoadingCache
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.ActionCoords
 import io.github.typesafegithub.workflows.actionbindinggenerator.domain.prettyPrintWithoutVersion
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
+import io.ktor.server.routing.head
 import io.ktor.server.routing.route
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
@@ -25,15 +27,41 @@ fun Routing.metadataRoutes(
     }
 
     route("{owner}/{name}/{file}") {
-        metadata(metadataCache)
+        headMetadata(metadataCache)
+        getMetadata(metadataCache)
     }
 
     route("/refresh/{owner}/{name}/{file}") {
-        metadata(metadataCache, refresh = true)
+        headMetadata(metadataCache, refresh = true)
+        getMetadata(metadataCache, refresh = true)
     }
 }
 
-private fun Route.metadata(
+private fun Route.headMetadata(
+    metadataCache: LoadingCache<ActionCoords, CachedMetadataArtifact>,
+    refresh: Boolean = false,
+) {
+    head {
+        val actionCoords = call.parameters.extractActionCoords(extractVersion = false)
+
+        if (refresh) {
+            metadataCache.invalidate(actionCoords)
+        }
+        val metadataArtifacts = metadataCache.get(actionCoords)
+
+        if (refresh && !deliverOnRefreshRoute) return@head call.respondText(text = "OK")
+
+        val file = call.parameters["file"] ?: return@head call.respondNotFound()
+
+        if (file in metadataArtifacts) {
+            call.respondText(text = "Exists", status = HttpStatusCode.OK)
+        } else {
+            call.respondNotFound()
+        }
+    }
+}
+
+private fun Route.getMetadata(
     metadataCache: LoadingCache<ActionCoords, CachedMetadataArtifact>,
     refresh: Boolean = false,
 ) {


### PR DESCRIPTION
An immediate reason to add it is enabling uptimerobot.com to display a status page: https://stats.uptimerobot.com/LHZ1ok6INN. In the free tier, it uses HEAD requests instead of GET, and HEAD is missing for metadata/versions.