### PR TITLE
test(server): add test for requesting non-existent artifact twice

### DIFF
--- a/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
+++ b/jit-binding-server/src/test/kotlin/io/github/typesafegithub/workflows/jitbindingserver/ArtifactRoutesTest.kt
@@ -64,6 +64,38 @@ class ArtifactRoutesTest :
                 }
             }
 
+            test("when artifacts is not available, two requests in a row") {
+                testApplication {
+                    // Given
+                    val mockBuildVersionArtifacts = mockk<(ActionCoords, HttpClient) -> VersionArtifacts?>()
+                    every { mockBuildVersionArtifacts(any(), any()) } returns null
+                    application {
+                        appModule(
+                            buildVersionArtifacts = mockBuildVersionArtifacts,
+                            // Irrelevant for these tests.
+                            buildPackageArtifacts = { _, _, _, _ -> emptyMap() },
+                            getGithubAuthToken = { "" },
+                        )
+                    }
+
+                    // When
+                    val response = client.get("some-owner/some-action/v4/some-action-v4.pom")
+                    // Then
+                    response.status shouldBe HttpStatusCode.NotFound
+
+                    // When
+                    val response2 = client.get("some-owner/some-action/v4/some-action-v4.pom")
+                    // Then
+                    response2.status shouldBe HttpStatusCode.NotFound
+
+                    // This test shows the current behavior where requesting a resource
+                    // that doesn't exist twice in a row causes calling the version artifact
+                    // twice.
+                    // Fix in scope of https://github.com/typesafegithub/github-workflows-kt/issues/2160
+                    verify(exactly = 2) { mockBuildVersionArtifacts(any(), any()) }
+                }
+            }
+
             test("when binding generation fails") {
                 testApplication {
                     // Given


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/2160, will let us fix the behavior by caching the response of non-existent resource.