### PR TITLE
test: add test for listing versions for branches and tags starting with 'v'

### DIFF
--- a/shared-internal/src/test/kotlin/io/github/typesafegithub/workflows/shared/internal/model/GithubApiTest.kt
+++ b/shared-internal/src/test/kotlin/io/github/typesafegithub/workflows/shared/internal/model/GithubApiTest.kt
@@ -109,6 +109,117 @@ class GithubApiTest :
                         Version("v2"),
                     ).right()
             }
+            test("scoped branches and tags starting with v") {
+                // Given
+                val tagsResponse =
+                    """
+                    [
+                        {
+                            "ref":"refs/tags/v1.0.0",
+                            "node_id":"MDM6UmVmMTk3ODE0NjI5OnJlZnMvdGFncy92MQ==",
+                            "url":"https://api.github.com/repos/some-owner/some-name/git/refs/tags/v1",
+                            "object": {
+                                "sha":"544eadc6bf3d226fd7a7a9f0dc5b5bf7ca0675b9",
+                                "type":"tag",
+                                "url":"https://api.github.com/repos/actions/some-name/git/tags/544eadc6bf3d226fd7a7a9f0dc5b5bf7ca0675b9"
+                            }
+                        },
+                        {
+                            "ref":"refs/tags/v1.0.1",
+                            "node_id":"MDM6UmVmMTk3ODE0NjI5OnJlZnMvdGFncy92MQ==",
+                            "url":"https://api.github.com/repos/some-owner/some-name/git/refs/tags/v1.0.1",
+                            "object": {
+                                "sha":"af513c7a016048ae468971c52ed77d9562c7c819",
+                                "type":"tag",
+                                "url":"https://api.github.com/repos/actions/some-name/git/tags/af513c7a016048ae468971c52ed77d9562c7c819"
+                            }
+                        },
+                        {
+                            "ref":"refs/tags/virtual/tag",
+                            "node_id":"MDM6UmVmMTk3ODE0NjI5OnJlZnMvdGFncy92MQ==",
+                            "url":"https://api.github.com/repos/some-owner/some-name/git/refs/tags/virtual/tag",
+                            "object": {
+                                "sha":"af513c7a016048ae468971c52ed77d9562c7c819",
+                                "type":"tag",
+                                "url":"https://api.github.com/repos/actions/some-name/git/tags/af513c7a016048ae468971c52ed77d9562c7c819"
+                            }
+                        }
+                    ]
+                    """.trimIndent()
+                val headsResponse =
+                    """
+                    [
+                        {
+                            "ref":"refs/heads/v1",
+                            "node_id":"MDM6UmVmMTk3ODE0NjI5OnJlZnMvaGVhZHMvdm1qb3NlcGgvc2lsZW50LXJldi1wYXJzZQ==",
+                            "url":"https://api.github.com/repos/some-owner/some-name/git/refs/heads/v1",
+                            "object": {
+                                "sha":"af5130cb8882054eda385840657dcbd1e19ab8f4",
+                                "type":"commit",
+                                "url":"https://api.github.com/repos/some-owner/some-name/git/commits/af5130cb8882054eda385840657dcbd1e19ab8f4"
+                            }
+                        },
+                        {
+                            "ref":"refs/heads/v2",
+                            "node_id":"MDM6UmVmMTk3ODE0NjI5OnJlZnMvaGVhZHMvdm1qb3NlcGgvdG9vbGtpdC13aW5kb3dzLWV4ZWM=",
+                            "url":"https://api.github.com/repos/some-owner/some-name/git/refs/heads/v2",
+                            "object": {
+                                "sha":"c22ccee38a13e34cb01a103c324adb1db665821e",
+                                "type":"commit",
+                                "url":"https://api.github.com/repos/some-owner/some-name/git/commits/c22ccee38a13e34cb01a103c324adb1db665821e"
+                            }
+                        },
+                        {
+                            "ref":"refs/heads/virtual/branch",
+                            "node_id":"MDM6UmVmMTk3ODE0NjI5OnJlZnMvaGVhZHMvdm1qb3NlcGgvdG9vbGtpdC13aW5kb3dzLWV4ZWM=",
+                            "url":"https://api.github.com/repos/some-owner/some-name/git/refs/heads/virtual/branch",
+                            "object": {
+                                "sha":"c22ccee38a13e34cb01a103c324adb1db665821e",
+                                "type":"commit",
+                                "url":"https://api.github.com/repos/some-owner/some-name/git/commits/c22ccee38a13e34cb01a103c324adb1db665821e"
+                            }
+                        }
+                    ]
+                    """.trimIndent()
+                mockServer
+                    .`when`(request().withPath("/repos/$owner/$name/git/matching-refs/tags/v"))
+                    .respond(
+                        response()
+                            .withStatusCode(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(tagsResponse),
+                    )
+                mockServer
+                    .`when`(request().withPath("/repos/$owner/$name/git/matching-refs/heads/v"))
+                    .respond(
+                        response()
+                            .withStatusCode(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(headsResponse),
+                    )
+
+                // When
+                val versionsOrError =
+                    fetchAvailableVersions(
+                        owner = owner,
+                        name = name,
+                        githubAuthToken = "token",
+                        githubEndpoint = "http://localhost:${mockServer.port}",
+                    )
+
+                // Then
+                // This assertion shows current undesired behavior,
+                // TODO fix in https://github.com/typesafegithub/github-workflows-kt/pull/2306
+                versionsOrError shouldBe
+                    listOf(
+                        Version("v1.0.0"),
+                        Version("v1.0.1"),
+                        Version("tag"),
+                        Version("v1"),
+                        Version("v2"),
+                        Version("branch"),
+                    ).right()
+            }
 
             test("error occurs when fetching branches and tags") {
                 // Given


### PR DESCRIPTION
Adding a test before fixing the problem in https://github.com/typesafegithub/github-workflows-kt/pull/2306.