### PR TITLE
feat(library)!: infer version of actions/checkout in consistency check job from classpath by default

### DIFF
--- a/action-updates-checker/src/test/kotlin/io/github/typesafegithub/workflows/updates/ReportingTest.kt
+++ b/action-updates-checker/src/test/kotlin/io/github/typesafegithub/workflows/updates/ReportingTest.kt
@@ -37,9 +37,10 @@ class ReportingTest :
                         name = "Test workflow",
                         on = listOf(Push()),
                         sourceFile = sourceTempFile,
-                        consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
-                            checkoutActionVersion = CheckoutActionVersionSource.Given("v4"),
-                        ),
+                        consistencyCheckJobConfig =
+                            DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
+                                checkoutActionVersion = CheckoutActionVersionSource.Given("v4"),
+                            ),
                         useWorkflow = { output = function(it) },
                     ) {
                         job(

--- a/action-updates-checker/src/test/kotlin/io/github/typesafegithub/workflows/updates/ReportingTest.kt
+++ b/action-updates-checker/src/test/kotlin/io/github/typesafegithub/workflows/updates/ReportingTest.kt
@@ -6,6 +6,8 @@ import io.github.typesafegithub.workflows.domain.actions.CustomAction
 import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.workflow
 import io.github.typesafegithub.workflows.shared.internal.getGithubAuthTokenOrNull
+import io.github.typesafegithub.workflows.yaml.CheckoutActionVersionSource
+import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.spec.tempdir
@@ -35,6 +37,9 @@ class ReportingTest :
                         name = "Test workflow",
                         on = listOf(Push()),
                         sourceFile = sourceTempFile,
+                        consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
+                            checkoutActionVersion = CheckoutActionVersionSource.Given("v4"),
+                        ),
                         useWorkflow = { output = function(it) },
                     ) {
                         job(

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/ConsistencyCheckJobConfig.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/ConsistencyCheckJobConfig.kt
@@ -7,7 +7,7 @@ public val DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG: ConsistencyCheckJobConfig.Confi
     ConsistencyCheckJobConfig.Configuration(
         condition = null,
         env = emptyMap(),
-        checkoutActionVersion = CheckoutActionVersionSource.BundledWithLibrary,
+        checkoutActionVersion = CheckoutActionVersionSource.InferFromClasspath(),
         additionalSteps = null,
         useLocalBindingsServerAsFallback = false,
     )

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/IntegrationTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/IntegrationTest.kt
@@ -86,7 +86,7 @@ class IntegrationTest :
                     steps:
                     - id: 'step-0'
                       name: 'Check out'
-                      uses: 'actions/checkout@v6'
+                      uses: 'actions/checkout@v4'
                     - id: 'step-1'
                       name: 'Execute script'
                       run: 'rm ''.github/workflows/some_workflow.yaml'' && ''.github/workflows/some_workflow.main.kts'''
@@ -282,7 +282,7 @@ class IntegrationTest :
                     steps:
                     - id: 'step-0'
                       name: 'Check out'
-                      uses: 'actions/checkout@v6'
+                      uses: 'actions/checkout@v4'
                     - id: 'step-1'
                       name: 'Execute script'
                       continue-on-error: true
@@ -722,7 +722,7 @@ class IntegrationTest :
                     steps:
                     - id: 'step-0'
                       name: 'Check out'
-                      uses: 'actions/checkout@v6'
+                      uses: 'actions/checkout@v4'
                     - id: 'step-1'
                       name: 'Execute script'
                       run: 'rm ''.github/workflows/some_workflow.yaml'' && ''.github/workflows/some_workflow.main.kts'''


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/2184.

This is the new default mainly because it works well with dependency updating bots, and rarely someone wants to have a different version of actions/checkout in the consistency check job than in the actual user-specified jobs. If needed, `CheckoutActionVersionSource` sealed interface is powerful enough to specify any desired version.