### PR TITLE
fix(library)!: rename/move `Type` classes in ambiguous contexts

### DIFF
--- a/github-workflows-kt/api/github-workflows-kt.api
+++ b/github-workflows-kt/api/github-workflows-kt.api
@@ -1371,31 +1371,31 @@ public final class io/github/typesafegithub/workflows/domain/triggers/PullReques
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$Type : java/lang/Enum {
-	public static final field Assigned Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field AutoMergeDisabled Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field AutoMergeEnabled Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Closed Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type$Companion;
-	public static final field ConvertedToDraft Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Edited Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Labeled Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Locked Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Opened Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field ReadyForReview Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Reopened Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field ReviewRequestRemoved Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field ReviewRequested Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Synchronize Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Unassigned Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Unlabeled Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static final field Unlocked Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType : java/lang/Enum {
+	public static final field Assigned Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field AutoMergeDisabled Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field AutoMergeEnabled Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Closed Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Companion;
+	public static final field ConvertedToDraft Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Edited Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Labeled Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Locked Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Opened Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field ReadyForReview Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Reopened Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field ReviewRequestRemoved Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field ReviewRequested Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Synchronize Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Unassigned Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Unlabeled Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static final field Unlocked Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
-	public static fun values ()[Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$Type;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
+	public static fun values ()[Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType;
 }
 
-public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$Type$Companion {
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1496,31 +1496,31 @@ public final class io/github/typesafegithub/workflows/domain/triggers/PullReques
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type : java/lang/Enum {
-	public static final field Assigned Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field AutoMergeDisabled Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field AutoMergeEnabled Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Closed Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type$Companion;
-	public static final field ConvertedToDraft Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Edited Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Labeled Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Locked Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Opened Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field ReadyForReview Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Reopened Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field ReviewRequestRemoved Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field ReviewRequested Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Synchronize Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Unassigned Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Unlabeled Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static final field Unlocked Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType : java/lang/Enum {
+	public static final field Assigned Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field AutoMergeDisabled Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field AutoMergeEnabled Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Closed Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Companion;
+	public static final field ConvertedToDraft Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Edited Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Labeled Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Locked Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Opened Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field ReadyForReview Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Reopened Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field ReviewRequestRemoved Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field ReviewRequested Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Synchronize Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Unassigned Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Unlabeled Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static final field Unlocked Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
-	public static fun values ()[Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
+	public static fun values ()[Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType;
 }
 
-public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$Type$Companion {
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1773,12 +1773,12 @@ public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowCa
 
 public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Companion;
-	public fun <init> (Ljava/lang/String;ZLio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ZLio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDefault ()Ljava/lang/String;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getRequired ()Z
-	public final fun getType ()Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type;
+	public final fun getType ()Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type;
 }
 
 public final synthetic class io/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -1793,6 +1793,20 @@ public final synthetic class io/github/typesafegithub/workflows/domain/triggers/
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type : java/lang/Enum {
+	public static final field Boolean Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type;
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type$Companion;
+	public static final field Number Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type;
+	public static final field String Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type;
+	public static fun values ()[Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Input$Type$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1840,20 +1854,6 @@ public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowCa
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type : java/lang/Enum {
-	public static final field Boolean Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type;
-	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type$Companion;
-	public static final field Number Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type;
-	public static final field String Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type;
-	public static fun values ()[Lio/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type;
-}
-
-public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowCall$Type$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
 public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Companion;
 	public fun <init> ()V
@@ -1887,13 +1887,13 @@ public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowDi
 
 public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Companion;
-	public fun <init> (Ljava/lang/String;ZLio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;Ljava/util/List;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ZLio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDefault ()Ljava/lang/String;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getOptions ()Ljava/util/List;
 	public final fun getRequired ()Z
-	public final fun getType ()Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
+	public final fun getType ()Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type;
 }
 
 public final synthetic class io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -1911,19 +1911,19 @@ public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowDi
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type : java/lang/Enum {
-	public static final field Boolean Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
-	public static final field Choice Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
-	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type$Companion;
-	public static final field Environment Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
-	public static final field Number Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
-	public static final field String Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
+public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type : java/lang/Enum {
+	public static final field Boolean Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type;
+	public static final field Choice Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type;
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type$Companion;
+	public static final field Environment Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type;
+	public static final field Number Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type;
+	public static final field String Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
-	public static fun values ()[Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type;
+	public static fun values ()[Lio/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type;
 }
 
-public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Type$Companion {
+public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch$Input$Type$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequest.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequest.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class PullRequest(
-    val types: List<Type> = emptyList(),
+    val types: List<EventType> = emptyList(),
     val branches: List<String>? = null,
     val branchesIgnore: List<String>? = null,
     val paths: List<String>? = null,
@@ -24,14 +24,14 @@ public data class PullRequest(
     }
 
     @InternalSerializationApi
-    internal class Serializer : CaseEnumSerializer<Type>(Type::class.qualifiedName!!, Type.values())
+    internal class Serializer : CaseEnumSerializer<EventType>(EventType::class.qualifiedName!!, EventType.values())
 
     /**
      * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
      */
     @OptIn(InternalSerializationApi::class)
     @Serializable(with = Serializer::class)
-    public enum class Type {
+    public enum class EventType {
         Assigned,
         Unassigned,
         Labeled,

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 // https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
 @Serializable
 public data class PullRequestTarget(
-    val types: List<Type> = emptyList(),
+    val types: List<EventType> = emptyList(),
     val branches: List<String>? = null,
     val branchesIgnore: List<String>? = null,
     val paths: List<String>? = null,
@@ -25,11 +25,11 @@ public data class PullRequestTarget(
     }
 
     @InternalSerializationApi
-    internal class Serializer : CaseEnumSerializer<Type>(Type::class.qualifiedName!!, Type.values())
+    internal class Serializer : CaseEnumSerializer<EventType>(EventType::class.qualifiedName!!, EventType.values())
 
     @OptIn(InternalSerializationApi::class)
     @Serializable(with = Serializer::class)
-    public enum class Type {
+    public enum class EventType {
         Assigned,
         Unassigned,
         Labeled,

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowCall.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowCall.kt
@@ -15,24 +15,24 @@ public data class WorkflowCall(
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
 ) : Trigger() {
     @Serializable
-    public enum class Type {
-        @SerialName("boolean")
-        Boolean,
-
-        @SerialName("number")
-        Number,
-
-        @SerialName("string")
-        String,
-    }
-
-    @Serializable
     public class Input(
         public val description: String,
         public val required: Boolean,
         public val type: Type,
         public val default: String? = null,
-    )
+    ) {
+        @Serializable
+        public enum class Type {
+            @SerialName("boolean")
+            Boolean,
+
+            @SerialName("number")
+            Number,
+
+            @SerialName("string")
+            String,
+        }
+    }
 
     @Serializable
     public class Output(

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowDispatch.kt
@@ -11,29 +11,29 @@ public data class WorkflowDispatch(
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
 ) : Trigger() {
     @Serializable
-    public enum class Type {
-        @SerialName("choice")
-        Choice,
-
-        @SerialName("environment")
-        Environment,
-
-        @SerialName("boolean")
-        Boolean,
-
-        @SerialName("number")
-        Number,
-
-        @SerialName("string")
-        String,
-    }
-
-    @Serializable
     public class Input(
         public val description: String,
         public val required: Boolean,
         public val type: Type,
         public val options: List<String> = emptyList(),
         public val default: String? = null,
-    )
+    ) {
+        @Serializable
+        public enum class Type {
+            @SerialName("choice")
+            Choice,
+
+            @SerialName("environment")
+            Environment,
+
+            @SerialName("boolean")
+            Boolean,
+
+            @SerialName("number")
+            Number,
+
+            @SerialName("string")
+            String,
+        }
+    }
 }

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/yaml/CaseTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/yaml/CaseTest.kt
@@ -1,7 +1,7 @@
 package io.github.typesafegithub.workflows.yaml
 
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
-import io.github.typesafegithub.workflows.domain.triggers.PullRequest.Type
+import io.github.typesafegithub.workflows.domain.triggers.PullRequest.EventType
 import io.github.typesafegithub.workflows.domain.triggers.PullRequestTarget
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.DescribeSpec
@@ -12,9 +12,9 @@ class CaseTest :
     DescribeSpec({
         it("transforms to pascal case") {
             listOf(
-                Type.Assigned to "assigned",
-                Type.AutoMergeDisabled to "auto_merge_disabled",
-                Type.ReviewRequested to "review_requested",
+                EventType.Assigned to "assigned",
+                EventType.AutoMergeDisabled to "auto_merge_disabled",
+                EventType.ReviewRequested to "review_requested",
             ).forAll { (type, expected) ->
                 type.toSnakeCase() shouldBe expected
             }
@@ -29,8 +29,8 @@ class CaseTest :
         }
 
         it("all enums should be in pascal case") {
-            PullRequestTarget.Type.values().forAll { it.toSnakeCase() }
-            PullRequest.Type.values().forAll { it.toSnakeCase() }
+            PullRequestTarget.EventType.values().forAll { it.toSnakeCase() }
+            PullRequest.EventType.values().forAll { it.toSnakeCase() }
         }
     })
 

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/yaml/TriggersToYamlTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/yaml/TriggersToYamlTest.kt
@@ -57,7 +57,7 @@ class TriggersToYamlTest :
                                     "logLevel" to
                                         WorkflowDispatch.Input(
                                             description = "Log level",
-                                            type = WorkflowDispatch.Type.Choice,
+                                            type = WorkflowDispatch.Input.Type.Choice,
                                             required = true,
                                             default = "warning",
                                             options = listOf("info", "warning", "debug"),
@@ -65,25 +65,25 @@ class TriggersToYamlTest :
                                     "tags" to
                                         WorkflowDispatch.Input(
                                             description = "Test scenario tags",
-                                            type = WorkflowDispatch.Type.Boolean,
+                                            type = WorkflowDispatch.Input.Type.Boolean,
                                             required = false,
                                         ),
                                     "retries" to
                                         WorkflowDispatch.Input(
                                             description = "Number of retries",
-                                            type = WorkflowDispatch.Type.Number,
+                                            type = WorkflowDispatch.Input.Type.Number,
                                             required = false,
                                         ),
                                     "environment" to
                                         WorkflowDispatch.Input(
                                             description = "Environment to run tests against",
-                                            type = WorkflowDispatch.Type.Environment,
+                                            type = WorkflowDispatch.Input.Type.Environment,
                                             required = true,
                                         ),
                                     "greeting" to
                                         WorkflowDispatch.Input(
                                             description = "Hello {greeting}",
-                                            type = WorkflowDispatch.Type.String,
+                                            type = WorkflowDispatch.Input.Type.String,
                                             required = true,
                                         ),
                                 ),
@@ -163,7 +163,7 @@ class TriggersToYamlTest :
                                     "tags" to
                                         WorkflowCall.Input(
                                             description = "Test scenario tags",
-                                            type = WorkflowCall.Type.Boolean,
+                                            type = WorkflowCall.Input.Type.Boolean,
                                             required = false,
                                         ),
                                 ),
@@ -201,19 +201,19 @@ class TriggersToYamlTest :
                                     "tags" to
                                         WorkflowCall.Input(
                                             description = "Test scenario tags",
-                                            type = WorkflowCall.Type.Boolean,
+                                            type = WorkflowCall.Input.Type.Boolean,
                                             required = false,
                                         ),
                                     "retries" to
                                         WorkflowCall.Input(
                                             description = "How many retries",
-                                            type = WorkflowCall.Type.Number,
+                                            type = WorkflowCall.Input.Type.Number,
                                             required = false,
                                         ),
                                     "greeting" to
                                         WorkflowCall.Input(
                                             description = "Hello {greeting}",
-                                            type = WorkflowCall.Type.String,
+                                            type = WorkflowCall.Input.Type.String,
                                             required = true,
                                         ),
                                 ),
@@ -375,7 +375,7 @@ class TriggersToYamlTest :
                         PullRequest(
                             branches = listOf("branch1", "branch2"),
                             paths = listOf("path1", "path2"),
-                            types = listOf(PullRequest.Type.AutoMergeDisabled, PullRequest.Type.Opened),
+                            types = listOf(PullRequest.EventType.AutoMergeDisabled, PullRequest.EventType.Opened),
                         ),
                     )
 
@@ -439,7 +439,7 @@ class TriggersToYamlTest :
                 val triggers =
                     listOf(
                         PullRequestTarget(
-                            types = listOf(PullRequestTarget.Type.Assigned, PullRequestTarget.Type.Closed),
+                            types = listOf(PullRequestTarget.EventType.Assigned, PullRequestTarget.EventType.Closed),
                             branches = listOf("branch1", "branch2"),
                             paths = listOf("path1", "path2"),
                         ),
@@ -465,7 +465,7 @@ class TriggersToYamlTest :
                 val triggers =
                     listOf(
                         PullRequestTarget(
-                            types = listOf(PullRequestTarget.Type.Assigned, PullRequestTarget.Type.Closed),
+                            types = listOf(PullRequestTarget.EventType.Assigned, PullRequestTarget.EventType.Closed),
                             branchesIgnore = listOf("branchIgnore1", "branchIgnore2"),
                             pathsIgnore = listOf("pathIgnore1", "pathIgnore2"),
                         ),


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/1789.