### PR TITLE
feat(library)!: update supported GitHub-hosted runners

### DIFF
--- a/github-workflows-kt/api/github-workflows-kt.api
+++ b/github-workflows-kt/api/github-workflows-kt.api
@@ -457,36 +457,56 @@ public final class io/github/typesafegithub/workflows/domain/RunnerType$Labelled
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/github/typesafegithub/workflows/domain/RunnerType$Macos1015 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Macos1015;
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Macos14 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Macos14;
 }
 
-public final class io/github/typesafegithub/workflows/domain/RunnerType$Macos11 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Macos11;
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Macos15 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Macos15;
+}
+
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Macos15Intel : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Macos15Intel;
+}
+
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Macos26 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Macos26;
+}
+
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Macos26Intel : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Macos26Intel;
 }
 
 public final class io/github/typesafegithub/workflows/domain/RunnerType$MacosLatest : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
 	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$MacosLatest;
 }
 
-public final class io/github/typesafegithub/workflows/domain/RunnerType$Ubuntu1804 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Ubuntu1804;
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Ubuntu2204 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Ubuntu2204;
 }
 
-public final class io/github/typesafegithub/workflows/domain/RunnerType$Ubuntu2004 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Ubuntu2004;
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Ubuntu2204Arm : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Ubuntu2204Arm;
+}
+
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Ubuntu2404 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Ubuntu2404;
+}
+
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Ubuntu2404Arm : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Ubuntu2404Arm;
 }
 
 public final class io/github/typesafegithub/workflows/domain/RunnerType$UbuntuLatest : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
 	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$UbuntuLatest;
 }
 
-public final class io/github/typesafegithub/workflows/domain/RunnerType$Windows2016 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Windows2016;
+public final class io/github/typesafegithub/workflows/domain/RunnerType$UbuntuSlim : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$UbuntuSlim;
 }
 
-public final class io/github/typesafegithub/workflows/domain/RunnerType$Windows2019 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Windows2019;
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Windows11Arm : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Windows11Arm;
 }
 
 public final class io/github/typesafegithub/workflows/domain/RunnerType$Windows2022 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
@@ -495,6 +515,10 @@ public final class io/github/typesafegithub/workflows/domain/RunnerType$Windows2
 
 public final class io/github/typesafegithub/workflows/domain/RunnerType$Windows2025 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
 	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Windows2025;
+}
+
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Windows2025Vs2026 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Windows2025Vs2026;
 }
 
 public final class io/github/typesafegithub/workflows/domain/RunnerType$WindowsLatest : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/RunnerType.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/RunnerType.kt
@@ -19,21 +19,33 @@ public sealed interface RunnerType {
     // Windows runners
     public object Windows2025 : GitHubHosted("windows-2025")
 
+    public object Windows2025Vs2026 : GitHubHosted("windows-2025-vs2026")
+
     public object Windows2022 : GitHubHosted("windows-2022")
 
-    public object Windows2019 : GitHubHosted("windows-2019")
-
-    public object Windows2016 : GitHubHosted("windows-2016")
+    public object Windows11Arm : GitHubHosted("windows-11-arm")
 
     // Ubuntu runners
-    public object Ubuntu2004 : GitHubHosted("ubuntu-20.04")
+    public object UbuntuSlim : GitHubHosted("ubuntu-slim")
 
-    public object Ubuntu1804 : GitHubHosted("ubuntu-18.04")
+    public object Ubuntu2404 : GitHubHosted("ubuntu-24.04")
+
+    public object Ubuntu2404Arm : GitHubHosted("ubuntu-24.04-arm")
+
+    public object Ubuntu2204 : GitHubHosted("ubuntu-22.04")
+
+    public object Ubuntu2204Arm : GitHubHosted("ubuntu-22.04-arm")
 
     // macOS runners
-    public object Macos11 : GitHubHosted("macos-11")
+    public object Macos26 : GitHubHosted("macos-26")
 
-    public object Macos1015 : GitHubHosted("macos-10.15")
+    public object Macos26Intel : GitHubHosted("macos-26-intel")
+
+    public object Macos15 : GitHubHosted("macos-15")
+
+    public object Macos15Intel : GitHubHosted("macos-15-intel")
+
+    public object Macos14 : GitHubHosted("macos-14")
 
     // Custom runner. Could be an expression `runsOn = expr("github.event.inputs.run-on")`
     public data class Custom(

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/GithubHostedRunnerLabelsListing.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/GithubHostedRunnerLabelsListing.kt
@@ -7,7 +7,7 @@ import io.ktor.client.statement.bodyAsText
 /**
  * Lists values allowed to be set in "runs-on" for a job, for GitHub-hosted runners.
  */
-suspend fun listRunnerLabels(): List<String> {
+suspend fun listRunnerLabels(): Set<String> {
     val html = HttpClient().get(GITHUB_RUNNER_LABELS_DOCS_URL).bodyAsText()
     return parse(html)
 }
@@ -15,11 +15,11 @@ suspend fun listRunnerLabels(): List<String> {
 private const val GITHUB_RUNNER_LABELS_DOCS_URL: String =
     "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions"
 
-private fun parse(html: String): List<String> =
+private fun parse(html: String): Set<String> =
     RUNNER_LABEL_REGEX
         .findAll(html)
         .map { it.groupValues[1] }
-        .toList()
+        .toSet()
 
 private val RUNNER_LABEL_REGEX =
     Regex(

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/RunnerTypeTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/RunnerTypeTest.kt
@@ -2,6 +2,7 @@ package io.github.typesafegithub.workflows.domain
 
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.util.Locale
@@ -33,6 +34,25 @@ class RunnerTypeTest :
                             }
 
                         actualClassName shouldBe classNameFromLabel
+                    }
+                }
+            }
+
+            test("all supported runner labels should correspond to lib's classes") {
+                val fromLib =
+                    RunnerType.GitHubHosted::class
+                        .sealedSubclasses
+                        .mapNotNull { it.objectInstance?.value }
+                        .toSet()
+                val fromDocs = listRunnerLabels().toSet()
+
+                assertSoftly {
+                    withClue("no obsolete labels are in the lib") {
+                        fromLib - fromDocs shouldBe emptySet<String>()
+                    }
+
+                    withClue("no missing labels are in the lib") {
+                        fromDocs - fromLib shouldBe emptySet<String>()
                     }
                 }
             }


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/2343.

Adds a test that compares runner types defined in code with the ones present in GitHub's docs.