### PR TITLE
chore(library)!: rename classes for Mac OS runners to be derived from labels

### DIFF
--- a/github-workflows-kt/api/github-workflows-kt.api
+++ b/github-workflows-kt/api/github-workflows-kt.api
@@ -457,16 +457,16 @@ public final class io/github/typesafegithub/workflows/domain/RunnerType$Labelled
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/github/typesafegithub/workflows/domain/RunnerType$MacOS1015 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$MacOS1015;
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Macos1015 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Macos1015;
 }
 
-public final class io/github/typesafegithub/workflows/domain/RunnerType$MacOS11 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$MacOS11;
+public final class io/github/typesafegithub/workflows/domain/RunnerType$Macos11 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$Macos11;
 }
 
-public final class io/github/typesafegithub/workflows/domain/RunnerType$MacOSLatest : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$MacOSLatest;
+public final class io/github/typesafegithub/workflows/domain/RunnerType$MacosLatest : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/RunnerType$MacosLatest;
 }
 
 public final class io/github/typesafegithub/workflows/domain/RunnerType$Ubuntu1804 : io/github/typesafegithub/workflows/domain/RunnerType$GitHubHosted {

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/RunnerType.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/RunnerType.kt
@@ -14,7 +14,7 @@ public sealed interface RunnerType {
 
     public object WindowsLatest : GitHubHosted("windows-latest")
 
-    public object MacOSLatest : GitHubHosted("macos-latest")
+    public object MacosLatest : GitHubHosted("macos-latest")
 
     // Windows runners
     public object Windows2025 : GitHubHosted("windows-2025")
@@ -31,9 +31,9 @@ public sealed interface RunnerType {
     public object Ubuntu1804 : GitHubHosted("ubuntu-18.04")
 
     // macOS runners
-    public object MacOS11 : GitHubHosted("macos-11")
+    public object Macos11 : GitHubHosted("macos-11")
 
-    public object MacOS1015 : GitHubHosted("macos-10.15")
+    public object Macos1015 : GitHubHosted("macos-10.15")
 
     // Custom runner. Could be an expression `runsOn = expr("github.event.inputs.run-on")`
     public data class Custom(

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/RunnerTypeTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/RunnerTypeTest.kt
@@ -1,10 +1,43 @@
 package io.github.typesafegithub.workflows.domain
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.util.Locale
 
 class RunnerTypeTest :
     FunSpec({
+        context("GitHub-hosted runners") {
+            test("classes should have names derived from labels using the convention") {
+                val runnerClasses =
+                    RunnerType.GitHubHosted::class
+                        .sealedSubclasses
+
+                assertSoftly {
+                    runnerClasses.forEach { runnerClass ->
+                        val actualClassName = runnerClass.simpleName
+                        val label = runnerClass.objectInstance!!.value
+                        val classNameFromLabel =
+                            label.split("-").joinToString("") {
+                                it
+                                    .replaceFirstChar {
+                                        if (it.isLowerCase()) {
+                                            it.titlecase(
+                                                Locale.getDefault(),
+                                            )
+                                        } else {
+                                            it.toString()
+                                        }
+                                    }.replace(".", "")
+                            }
+
+                        actualClassName shouldBe classNameFromLabel
+                    }
+                }
+            }
+        }
+
         context("Labelled") {
             test("should throw on invalid arguments") {
                 shouldThrow<IllegalArgumentException> {


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/2343.

Thanks to this change, there are clear rules how to derive runners' class names based on the runner label, and it will be easier to maintain the evolving collection of supported runners.