### PR TITLE
feat(library): support types for all triggers that support them

### DIFF
--- a/github-workflows-kt/api/github-workflows-kt.api
+++ b/github-workflows-kt/api/github-workflows-kt.api
@@ -828,12 +828,14 @@ public final class io/github/typesafegithub/workflows/domain/contexts/OutputsCon
 public final class io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -854,15 +856,52 @@ public final class io/github/typesafegithub/workflows/domain/triggers/BranchProt
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule$EventType$Edited;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/CheckRun : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/CheckRun$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/CheckRun;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/CheckRun;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/CheckRun;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/CheckRun;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/CheckRun;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/CheckRun;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -883,15 +922,56 @@ public final class io/github/typesafegithub/workflows/domain/triggers/CheckRun$C
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Completed : io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Completed;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$RequestedAction : io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$RequestedAction;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Rerequested : io/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/CheckRun$EventType$Rerequested;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/CheckSuite : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -910,6 +990,33 @@ public final synthetic class io/github/typesafegithub/workflows/domain/triggers/
 
 public final class io/github/typesafegithub/workflows/domain/triggers/CheckSuite$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class io/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType$Completed : io/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType$Completed;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/CheckSuite$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/Create : io/github/typesafegithub/workflows/domain/triggers/Trigger {
@@ -1058,12 +1165,14 @@ public final class io/github/typesafegithub/workflows/domain/triggers/Deployment
 public final class io/github/typesafegithub/workflows/domain/triggers/Discussion : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Discussion$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Discussion;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Discussion;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Discussion;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Discussion;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Discussion;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Discussion;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1084,15 +1193,92 @@ public final class io/github/typesafegithub/workflows/domain/triggers/Discussion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Answered : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Answered;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$CategoryChanged : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$CategoryChanged;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Edited;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Labeled : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Labeled;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Locked : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Locked;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Pinned : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Pinned;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Transferred : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Transferred;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Unanswered : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Unanswered;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Unlabeled : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Unlabeled;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Unlocked : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Unlocked;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Unpinned : io/github/typesafegithub/workflows/domain/triggers/Discussion$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Discussion$EventType$Unpinned;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/DiscussionComment : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1111,6 +1297,41 @@ public final synthetic class io/github/typesafegithub/workflows/domain/triggers/
 
 public final class io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/DiscussionComment$EventType$Edited;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/Fork : io/github/typesafegithub/workflows/domain/triggers/Trigger {
@@ -1203,12 +1424,14 @@ public final class io/github/typesafegithub/workflows/domain/triggers/ImageVersi
 public final class io/github/typesafegithub/workflows/domain/triggers/IssueComment : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/IssueComment$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/IssueComment;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/IssueComment;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/IssueComment;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/IssueComment;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/IssueComment;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/IssueComment;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1229,15 +1452,52 @@ public final class io/github/typesafegithub/workflows/domain/triggers/IssueComme
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class io/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/IssueComment$EventType$Edited;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/Issues : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Issues$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Issues;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Issues;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Issues;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Issues;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Issues;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Issues;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1258,15 +1518,120 @@ public final class io/github/typesafegithub/workflows/domain/triggers/Issues$Com
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Assigned : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Assigned;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Closed : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Closed;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Demilestoned : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Demilestoned;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Edited;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$FieldAdded : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$FieldAdded;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$FieldRemoved : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$FieldRemoved;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Labeled : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Labeled;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Locked : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Locked;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Milestoned : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Milestoned;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Opened : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Opened;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Pinned : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Pinned;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Reopened : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Reopened;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Transferred : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Transferred;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Typed : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Typed;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Unassigned : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Unassigned;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Unlabeled : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Unlabeled;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Unlocked : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Unlocked;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Unpinned : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Unpinned;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Untyped : io/github/typesafegithub/workflows/domain/triggers/Issues$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Issues$EventType$Untyped;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/Label : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Label$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Label;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Label;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Label;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Label;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Label;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Label;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1287,15 +1652,52 @@ public final class io/github/typesafegithub/workflows/domain/triggers/Label$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class io/github/typesafegithub/workflows/domain/triggers/Label$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Label$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/Label$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Label$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Label$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/Label$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Label$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Label$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/Label$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/Label$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Label$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Label$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Label$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/Label$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Label$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Label$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/Label$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Label$EventType$Edited;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/MergeGroup : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1316,15 +1718,44 @@ public final class io/github/typesafegithub/workflows/domain/triggers/MergeGroup
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class io/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType$ChecksRequested : io/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType$ChecksRequested;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/MergeGroup$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/Milestone : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Milestone$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Milestone;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Milestone;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Milestone;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Milestone;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Milestone;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Milestone;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1343,6 +1774,49 @@ public final synthetic class io/github/typesafegithub/workflows/domain/triggers/
 
 public final class io/github/typesafegithub/workflows/domain/triggers/Milestone$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/Milestone$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Closed : io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Closed;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Edited;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Opened : io/github/typesafegithub/workflows/domain/triggers/Milestone$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Milestone$EventType$Opened;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/PageBuild : io/github/typesafegithub/workflows/domain/triggers/Trigger {
@@ -1377,12 +1851,14 @@ public final class io/github/typesafegithub/workflows/domain/triggers/PageBuild$
 public final class io/github/typesafegithub/workflows/domain/triggers/Project : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Project$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Project;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Project;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Project;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Project;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Project;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Project;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1403,15 +1879,64 @@ public final class io/github/typesafegithub/workflows/domain/triggers/Project$Co
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class io/github/typesafegithub/workflows/domain/triggers/Project$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Project$EventType$Closed : io/github/typesafegithub/workflows/domain/triggers/Project$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType$Closed;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Project$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Project$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/Project$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Project$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/Project$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Project$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/Project$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Project$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/Project$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType$Edited;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Project$EventType$Reopened : io/github/typesafegithub/workflows/domain/triggers/Project$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType$Reopened;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Project$EventType$Updated : io/github/typesafegithub/workflows/domain/triggers/Project$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Project$EventType$Updated;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/ProjectCard : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1432,15 +1957,60 @@ public final class io/github/typesafegithub/workflows/domain/triggers/ProjectCar
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Converted : io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Converted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Edited;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Moved : io/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/ProjectCard$EventType$Moved;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/ProjectColumn : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1459,6 +2029,45 @@ public final synthetic class io/github/typesafegithub/workflows/domain/triggers/
 
 public final class io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Moved : io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Moved;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Updated : io/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/ProjectColumn$EventType$Updated;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/PublicWorkflow : io/github/typesafegithub/workflows/domain/triggers/Trigger {
@@ -1623,12 +2232,14 @@ public final class io/github/typesafegithub/workflows/domain/triggers/PullReques
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReview : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1649,15 +2260,52 @@ public final class io/github/typesafegithub/workflows/domain/triggers/PullReques
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class io/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Dismissed : io/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Dismissed;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Edited;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Submitted : io/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReview$EventType$Submitted;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1676,6 +2324,41 @@ public final synthetic class io/github/typesafegithub/workflows/domain/triggers/
 
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment$EventType$Edited;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget : io/github/typesafegithub/workflows/domain/triggers/Trigger {
@@ -1852,12 +2535,14 @@ public final class io/github/typesafegithub/workflows/domain/triggers/Push$Compa
 public final class io/github/typesafegithub/workflows/domain/triggers/RegistryPackage : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1876,6 +2561,37 @@ public final synthetic class io/github/typesafegithub/workflows/domain/triggers/
 
 public final class io/github/typesafegithub/workflows/domain/triggers/RegistryPackage$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class io/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType$Published : io/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType$Published;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType$Updated : io/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/RegistryPackage$EventType$Updated;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/Release : io/github/typesafegithub/workflows/domain/triggers/Trigger {
@@ -1994,12 +2710,14 @@ public abstract class io/github/typesafegithub/workflows/domain/triggers/Trigger
 public final class io/github/typesafegithub/workflows/domain/triggers/Watch : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Watch$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Watch;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Watch;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Watch;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/Watch;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Watch;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Watch;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -2018,6 +2736,33 @@ public final synthetic class io/github/typesafegithub/workflows/domain/triggers/
 
 public final class io/github/typesafegithub/workflows/domain/triggers/Watch$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class io/github/typesafegithub/workflows/domain/triggers/Watch$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Watch$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/Watch$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Watch$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Watch$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/Watch$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/Watch$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Watch$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Watch$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Watch$EventType$Started : io/github/typesafegithub/workflows/domain/triggers/Watch$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Watch$EventType$Started;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowCall : io/github/typesafegithub/workflows/domain/triggers/Trigger {
@@ -2270,12 +3015,14 @@ public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowDi
 public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun : io/github/typesafegithub/workflows/domain/triggers/Trigger {
 	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun;
-	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypes ()Ljava/util/List;
 	public fun get_customArguments ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -2294,6 +3041,45 @@ public final synthetic class io/github/typesafegithub/workflows/domain/triggers/
 
 public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Completed : io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Completed;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$InProgress : io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$InProgress;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Requested : io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Requested;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Waiting : io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Waiting;
 }
 
 public final class io/github/typesafegithub/workflows/dsl/ContainerKt {

--- a/github-workflows-kt/api/github-workflows-kt.api
+++ b/github-workflows-kt/api/github-workflows-kt.api
@@ -2181,8 +2181,20 @@ public final class io/github/typesafegithub/workflows/domain/triggers/PullReques
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Demilestoned : io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Demilestoned;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Dequeued : io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Dequeued;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType {
 	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Edited;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Enqueued : io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Enqueued;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Labeled : io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType {
@@ -2191,6 +2203,10 @@ public final class io/github/typesafegithub/workflows/domain/triggers/PullReques
 
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Locked : io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType {
 	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Locked;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Milestoned : io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Milestoned;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType$Opened : io/github/typesafegithub/workflows/domain/triggers/PullRequest$EventType {
@@ -2443,8 +2459,20 @@ public final class io/github/typesafegithub/workflows/domain/triggers/PullReques
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Demilestoned : io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Demilestoned;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Dequeued : io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Dequeued;
+}
+
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType {
 	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Edited;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Enqueued : io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Enqueued;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Labeled : io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType {
@@ -2453,6 +2481,10 @@ public final class io/github/typesafegithub/workflows/domain/triggers/PullReques
 
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Locked : io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType {
 	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Locked;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Milestoned : io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Milestoned;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType$Opened : io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget$EventType {
@@ -2623,6 +2655,57 @@ public final synthetic class io/github/typesafegithub/workflows/domain/triggers/
 
 public final class io/github/typesafegithub/workflows/domain/triggers/Release$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class io/github/typesafegithub/workflows/domain/triggers/Release$EventType {
+	public static final field Companion Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Release$EventType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Release$EventType$Created : io/github/typesafegithub/workflows/domain/triggers/Release$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Created;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Release$EventType$Custom : io/github/typesafegithub/workflows/domain/triggers/Release$EventType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Custom;
+	public static synthetic fun copy$default (Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Custom;Ljava/lang/String;ILjava/lang/Object;)Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Release$EventType$Deleted : io/github/typesafegithub/workflows/domain/triggers/Release$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Deleted;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Release$EventType$Edited : io/github/typesafegithub/workflows/domain/triggers/Release$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Edited;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Release$EventType$Prereleased : io/github/typesafegithub/workflows/domain/triggers/Release$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Prereleased;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Release$EventType$Published : io/github/typesafegithub/workflows/domain/triggers/Release$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Published;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Release$EventType$Released : io/github/typesafegithub/workflows/domain/triggers/Release$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Released;
+}
+
+public final class io/github/typesafegithub/workflows/domain/triggers/Release$EventType$Unpublished : io/github/typesafegithub/workflows/domain/triggers/Release$EventType {
+	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/Release$EventType$Unpublished;
 }
 
 public final class io/github/typesafegithub/workflows/domain/triggers/RepositoryDispatch : io/github/typesafegithub/workflows/domain/triggers/Trigger {
@@ -3076,10 +3159,6 @@ public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRu
 
 public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Requested : io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType {
 	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Requested;
-}
-
-public final class io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Waiting : io/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType {
-	public static final field INSTANCE Lio/github/typesafegithub/workflows/domain/triggers/WorkflowRun$EventType$Waiting;
 }
 
 public final class io/github/typesafegithub/workflows/dsl/ContainerKt {

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule.kt
@@ -1,9 +1,24 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class BranchProtectionRule(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Edited : EventType("edited")
+        public object Deleted : EventType("deleted")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/BranchProtectionRule.kt
@@ -15,8 +15,11 @@ public data class BranchProtectionRule(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Edited : EventType("edited")
+
         public object Deleted : EventType("deleted")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/CheckRun.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/CheckRun.kt
@@ -15,9 +15,13 @@ public data class CheckRun(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Rerequested : EventType("rerequested")
+
         public object Completed : EventType("completed")
+
         public object RequestedAction : EventType("requested_action")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/CheckRun.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/CheckRun.kt
@@ -1,9 +1,25 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class CheckRun(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Rerequested : EventType("rerequested")
+        public object Completed : EventType("completed")
+        public object RequestedAction : EventType("requested_action")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/CheckSuite.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/CheckSuite.kt
@@ -1,9 +1,22 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class CheckSuite(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Completed : EventType("completed")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/CheckSuite.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/CheckSuite.kt
@@ -15,6 +15,7 @@ public data class CheckSuite(
         public val name: String,
     ) {
         public object Completed : EventType("completed")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Discussion.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Discussion.kt
@@ -15,18 +15,31 @@ public data class Discussion(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Edited : EventType("edited")
+
         public object Deleted : EventType("deleted")
+
         public object Transferred : EventType("transferred")
+
         public object Pinned : EventType("pinned")
+
         public object Unpinned : EventType("unpinned")
+
         public object Labeled : EventType("labeled")
+
         public object Unlabeled : EventType("unlabeled")
+
         public object Locked : EventType("locked")
+
         public object Unlocked : EventType("unlocked")
+
         public object CategoryChanged : EventType("category_changed")
+
         public object Answered : EventType("answered")
+
         public object Unanswered : EventType("unanswered")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Discussion.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Discussion.kt
@@ -1,9 +1,34 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class Discussion(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Edited : EventType("edited")
+        public object Deleted : EventType("deleted")
+        public object Transferred : EventType("transferred")
+        public object Pinned : EventType("pinned")
+        public object Unpinned : EventType("unpinned")
+        public object Labeled : EventType("labeled")
+        public object Unlabeled : EventType("unlabeled")
+        public object Locked : EventType("locked")
+        public object Unlocked : EventType("unlocked")
+        public object CategoryChanged : EventType("category_changed")
+        public object Answered : EventType("answered")
+        public object Unanswered : EventType("unanswered")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/DiscussionComment.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/DiscussionComment.kt
@@ -1,9 +1,24 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
 @Serializable
 public data class DiscussionComment(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Edited : EventType("edited")
+        public object Deleted : EventType("deleted")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/DiscussionComment.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/DiscussionComment.kt
@@ -15,8 +15,11 @@ public data class DiscussionComment(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Edited : EventType("edited")
+
         public object Deleted : EventType("deleted")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/IssueComment.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/IssueComment.kt
@@ -15,8 +15,11 @@ public data class IssueComment(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Edited : EventType("edited")
+
         public object Deleted : EventType("deleted")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/IssueComment.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/IssueComment.kt
@@ -1,12 +1,24 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment
- */
 @Serializable
 public data class IssueComment(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Edited : EventType("edited")
+        public object Deleted : EventType("deleted")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Issues.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Issues.kt
@@ -1,12 +1,41 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issues
- */
 @Serializable
 public data class Issues(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Opened : EventType("opened")
+        public object Edited : EventType("edited")
+        public object Deleted : EventType("deleted")
+        public object Transferred : EventType("transferred")
+        public object Pinned : EventType("pinned")
+        public object Unpinned : EventType("unpinned")
+        public object Closed : EventType("closed")
+        public object Reopened : EventType("reopened")
+        public object Assigned : EventType("assigned")
+        public object Unassigned : EventType("unassigned")
+        public object Labeled : EventType("labeled")
+        public object Unlabeled : EventType("unlabeled")
+        public object Locked : EventType("locked")
+        public object Unlocked : EventType("unlocked")
+        public object Milestoned : EventType("milestoned")
+        public object Demilestoned : EventType("demilestoned")
+        public object Typed : EventType("typed")
+        public object Untyped : EventType("untyped")
+        public object FieldAdded : EventType("field_added")
+        public object FieldRemoved : EventType("field_removed")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Issues.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Issues.kt
@@ -15,25 +15,45 @@ public data class Issues(
         public val name: String,
     ) {
         public object Opened : EventType("opened")
+
         public object Edited : EventType("edited")
+
         public object Deleted : EventType("deleted")
+
         public object Transferred : EventType("transferred")
+
         public object Pinned : EventType("pinned")
+
         public object Unpinned : EventType("unpinned")
+
         public object Closed : EventType("closed")
+
         public object Reopened : EventType("reopened")
+
         public object Assigned : EventType("assigned")
+
         public object Unassigned : EventType("unassigned")
+
         public object Labeled : EventType("labeled")
+
         public object Unlabeled : EventType("unlabeled")
+
         public object Locked : EventType("locked")
+
         public object Unlocked : EventType("unlocked")
+
         public object Milestoned : EventType("milestoned")
+
         public object Demilestoned : EventType("demilestoned")
+
         public object Typed : EventType("typed")
+
         public object Untyped : EventType("untyped")
+
         public object FieldAdded : EventType("field_added")
+
         public object FieldRemoved : EventType("field_removed")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Label.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Label.kt
@@ -1,12 +1,24 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#label
- */
 @Serializable
 public data class Label(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Edited : EventType("edited")
+        public object Deleted : EventType("deleted")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Label.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Label.kt
@@ -15,8 +15,11 @@ public data class Label(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Edited : EventType("edited")
+
         public object Deleted : EventType("deleted")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/MergeGroup.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/MergeGroup.kt
@@ -15,6 +15,7 @@ public data class MergeGroup(
         public val name: String,
     ) {
         public object ChecksRequested : EventType("checks_requested")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/MergeGroup.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/MergeGroup.kt
@@ -1,12 +1,22 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
- */
 @Serializable
 public data class MergeGroup(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object ChecksRequested : EventType("checks_requested")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Milestone.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Milestone.kt
@@ -15,10 +15,15 @@ public data class Milestone(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Closed : EventType("closed")
+
         public object Opened : EventType("opened")
+
         public object Edited : EventType("edited")
+
         public object Deleted : EventType("deleted")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Milestone.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Milestone.kt
@@ -1,12 +1,26 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#milestone
- */
 @Serializable
 public data class Milestone(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Closed : EventType("closed")
+        public object Opened : EventType("opened")
+        public object Edited : EventType("edited")
+        public object Deleted : EventType("deleted")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Project.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Project.kt
@@ -15,11 +15,17 @@ public data class Project(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Updated : EventType("updated")
+
         public object Closed : EventType("closed")
+
         public object Reopened : EventType("reopened")
+
         public object Edited : EventType("edited")
+
         public object Deleted : EventType("deleted")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Project.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Project.kt
@@ -1,12 +1,27 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#project
- */
 @Serializable
 public data class Project(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Updated : EventType("updated")
+        public object Closed : EventType("closed")
+        public object Reopened : EventType("reopened")
+        public object Edited : EventType("edited")
+        public object Deleted : EventType("deleted")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/ProjectCard.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/ProjectCard.kt
@@ -15,10 +15,15 @@ public data class ProjectCard(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Moved : EventType("moved")
+
         public object Converted : EventType("converted")
+
         public object Edited : EventType("edited")
+
         public object Deleted : EventType("deleted")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/ProjectCard.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/ProjectCard.kt
@@ -1,12 +1,26 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#project
- */
 @Serializable
 public data class ProjectCard(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Moved : EventType("moved")
+        public object Converted : EventType("converted")
+        public object Edited : EventType("edited")
+        public object Deleted : EventType("deleted")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/ProjectColumn.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/ProjectColumn.kt
@@ -15,9 +15,13 @@ public data class ProjectColumn(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Updated : EventType("updated")
+
         public object Moved : EventType("moved")
+
         public object Deleted : EventType("deleted")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/ProjectColumn.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/ProjectColumn.kt
@@ -1,12 +1,25 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#project_column
- */
 @Serializable
 public data class ProjectColumn(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Updated : EventType("updated")
+        public object Moved : EventType("moved")
+        public object Deleted : EventType("deleted")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequest.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequest.kt
@@ -46,21 +46,29 @@ public data class PullRequest(
 
         public object Reopened : EventType("reopened")
 
-        public object Synchronize : EventType("synchronized")
+        public object Synchronize : EventType("synchronize")
 
-        public object ConvertedToDraft : EventType("convert_to_draft")
-
-        public object ReadyForReview : EventType("ready_for_review")
+        public object ConvertedToDraft : EventType("converted_to_draft")
 
         public object Locked : EventType("locked")
 
         public object Unlocked : EventType("unlocked")
 
+        public object Enqueued : EventType("enqueued")
+
+        public object Dequeued : EventType("dequeued")
+
+        public object Milestoned : EventType("milestoned")
+
+        public object Demilestoned : EventType("demilestoned")
+
+        public object ReadyForReview : EventType("ready_for_review")
+
         public object ReviewRequested : EventType("review_requested")
 
         public object ReviewRequestRemoved : EventType("review_request_removed")
 
-        public object AutoMergeEnabled : EventType("auto_merge")
+        public object AutoMergeEnabled : EventType("auto_merge_enabled")
 
         public object AutoMergeDisabled : EventType("auto_merge_disabled")
 

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestReview.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestReview.kt
@@ -1,12 +1,24 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_review
- */
 @Serializable
 public data class PullRequestReview(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Submitted : EventType("submitted")
+        public object Edited : EventType("edited")
+        public object Dismissed : EventType("dismissed")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestReview.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestReview.kt
@@ -15,8 +15,11 @@ public data class PullRequestReview(
         public val name: String,
     ) {
         public object Submitted : EventType("submitted")
+
         public object Edited : EventType("edited")
+
         public object Dismissed : EventType("dismissed")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment.kt
@@ -15,8 +15,11 @@ public data class PullRequestReviewComment(
         public val name: String,
     ) {
         public object Created : EventType("created")
+
         public object Edited : EventType("edited")
+
         public object Deleted : EventType("deleted")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestReviewComment.kt
@@ -1,12 +1,24 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_review_comment
- */
 @Serializable
 public data class PullRequestReviewComment(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Created : EventType("created")
+        public object Edited : EventType("edited")
+        public object Deleted : EventType("deleted")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/PullRequestTarget.kt
@@ -46,13 +46,21 @@ public data class PullRequestTarget(
 
         public object Synchronize : EventType("synchronize")
 
-        public object ConvertedToDraft : EventType("convert_to_draft")
-
-        public object ReadyForReview : EventType("ready_for_review")
+        public object ConvertedToDraft : EventType("converted_to_draft")
 
         public object Locked : EventType("locked")
 
         public object Unlocked : EventType("unlocked")
+
+        public object Enqueued : EventType("enqueued")
+
+        public object Dequeued : EventType("dequeued")
+
+        public object Milestoned : EventType("milestoned")
+
+        public object Demilestoned : EventType("demilestoned")
+
+        public object ReadyForReview : EventType("ready_for_review")
 
         public object ReviewRequested : EventType("review_requested")
 

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/RegistryPackage.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/RegistryPackage.kt
@@ -15,7 +15,9 @@ public data class RegistryPackage(
         public val name: String,
     ) {
         public object Published : EventType("published")
+
         public object Updated : EventType("updated")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/RegistryPackage.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/RegistryPackage.kt
@@ -1,12 +1,23 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#registry_package
- */
 @Serializable
 public data class RegistryPackage(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Published : EventType("published")
+        public object Updated : EventType("updated")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Release.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Release.kt
@@ -1,6 +1,8 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
+import io.github.typesafegithub.workflows.domain.triggers.PullRequestTarget.EventType
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
 /**
@@ -10,4 +12,28 @@ import kotlinx.serialization.Serializable
 public data class Release(
     val types: List<String>? = null,
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Published : EventType("published")
+
+        public object Unpublished : EventType("unpublished")
+
+        public object Created : EventType("created")
+
+        public object Edited : EventType("edited")
+
+        public object Deleted : EventType("deleted")
+
+        public object Prereleased : EventType("prerelease")
+
+        public object Released : EventType("released")
+
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Release.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Release.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 public data class Release(
-    val types: List<String>? = null,
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
 ) : Trigger() {
     @OptIn(InternalSerializationApi::class)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/RepositoryDispatch.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/RepositoryDispatch.kt
@@ -8,6 +8,6 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 public data class RepositoryDispatch(
-    val types: List<String>? = null,
+    val types: List<String> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
 ) : Trigger()

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Watch.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Watch.kt
@@ -15,6 +15,7 @@ public data class Watch(
         public val name: String,
     ) {
         public object Started : EventType("started")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Watch.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/Watch.kt
@@ -1,12 +1,22 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#watch
- */
 @Serializable
 public data class Watch(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Started : EventType("started")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowRun.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowRun.kt
@@ -15,9 +15,13 @@ public data class WorkflowRun(
         public val name: String,
     ) {
         public object Completed : EventType("completed")
+
         public object Requested : EventType("requested")
+
         public object InProgress : EventType("in_progress")
+
         public object Waiting : EventType("waiting")
+
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowRun.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowRun.kt
@@ -20,8 +20,6 @@ public data class WorkflowRun(
 
         public object InProgress : EventType("in_progress")
 
-        public object Waiting : EventType("waiting")
-
         public data class Custom(
             val value: String,
         ) : EventType(name = value)

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowRun.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/domain/triggers/WorkflowRun.kt
@@ -1,12 +1,25 @@
 package io.github.typesafegithub.workflows.domain.triggers
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
- */
 @Serializable
 public data class WorkflowRun(
+    val types: List<EventType> = emptyList(),
     override val _customArguments: Map<String, @Contextual Any> = mapOf(),
-) : Trigger()
+) : Trigger() {
+    @OptIn(InternalSerializationApi::class)
+    @Serializable
+    public sealed class EventType(
+        public val name: String,
+    ) {
+        public object Completed : EventType("completed")
+        public object Requested : EventType("requested")
+        public object InProgress : EventType("in_progress")
+        public object Waiting : EventType("waiting")
+        public data class Custom(
+            val value: String,
+        ) : EventType(name = value)
+    }
+}

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/TriggersToYaml.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/TriggersToYaml.kt
@@ -54,11 +54,29 @@ internal fun List<Trigger>.triggersToYaml(): Map<String, Any?> =
 @InternalGithubActionsApi
 public fun Trigger.toMap(): Map<String, List<String>> =
     when (this) {
-        is Push -> toMap()
+        is BranchProtectionRule -> toMap()
+        is CheckRun -> toMap()
+        is CheckSuite -> toMap()
+        is Discussion -> toMap()
+        is DiscussionComment -> toMap()
+        is IssueComment -> toMap()
+        is Issues -> toMap()
+        is Label -> toMap()
+        is MergeGroup -> toMap()
+        is Milestone -> toMap()
+        is Project -> toMap()
+        is ProjectCard -> toMap()
+        is ProjectColumn -> toMap()
         is PullRequest -> toMap()
+        is PullRequestReview -> toMap()
+        is PullRequestReviewComment -> toMap()
         is PullRequestTarget -> toMap()
-        is RepositoryDispatch -> toMap()
+        is Push -> toMap()
+        is RegistryPackage -> toMap()
         is Release -> toMap()
+        is RepositoryDispatch -> toMap()
+        is Watch -> toMap()
+        is WorkflowRun -> toMap()
         else -> emptyMap()
     }
 
@@ -95,9 +113,99 @@ private fun RepositoryDispatch.toMap() =
         "types" to types,
     )
 
+private fun BranchProtectionRule.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun CheckRun.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun CheckSuite.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun Discussion.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun DiscussionComment.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun IssueComment.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun Issues.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun Label.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun MergeGroup.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun Milestone.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun Project.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun ProjectCard.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun ProjectColumn.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun PullRequestReview.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun PullRequestReviewComment.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun RegistryPackage.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
 private fun Release.toMap() =
     mapOfNotNullValues(
         "types" to types,
+    )
+
+private fun Watch.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
+    )
+
+private fun WorkflowRun.toMap() =
+    mapOfNotNullValues(
+        "types" to types.ifEmpty { null }?.map { it.name },
     )
 
 @Suppress("ComplexMethod")

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/TriggersToYaml.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/TriggersToYaml.kt
@@ -51,6 +51,7 @@ internal fun List<Trigger>.triggersToYaml(): Map<String, Any?> =
         },
     )
 
+@Suppress("CyclomaticComplexMethod")
 @InternalGithubActionsApi
 public fun Trigger.toMap(): Map<String, List<String>> =
     when (this) {

--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/TriggersToYaml.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/TriggersToYaml.kt
@@ -111,7 +111,7 @@ private fun PullRequestTarget.toMap() =
 
 private fun RepositoryDispatch.toMap() =
     mapOfNotNullValues(
-        "types" to types,
+        "types" to types.ifEmpty { null },
     )
 
 private fun BranchProtectionRule.toMap() =
@@ -196,7 +196,7 @@ private fun RegistryPackage.toMap() =
 
 private fun Release.toMap() =
     mapOfNotNullValues(
-        "types" to types,
+        "types" to types.ifEmpty { null }?.map { it.name },
     )
 
 private fun Watch.toMap() =

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/triggers/OtherTriggersTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/triggers/OtherTriggersTest.kt
@@ -155,7 +155,7 @@ class OtherTriggersTest :
                     RegistryPackage(
                         types = listOf(RegistryPackage.EventType.Published, RegistryPackage.EventType.Updated),
                     ),
-                    Release(types = listOf("published", "unpublished")),
+                    Release(types = listOf(Release.EventType.Published, Release.EventType.Unpublished)),
                     RepositoryDispatch(types = listOf("foo", "bar")),
                     Schedule(emptyList()),
                     Status(

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/triggers/OtherTriggersTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/triggers/OtherTriggersTest.kt
@@ -88,48 +88,71 @@ class OtherTriggersTest :
         }
 
         test("Creating all triggers with free arguments") {
-            fun types(vararg types: String) =
-                mapOf(
-                    "types" to types.toList(),
-                )
-
             val triggers: List<Trigger> =
                 listOf(
-                    BranchProtectionRule(types("created", "deleted")),
-                    CheckRun(types("completed", "rerequested")),
+                    BranchProtectionRule(
+                        types = listOf(BranchProtectionRule.EventType.Created, BranchProtectionRule.EventType.Deleted),
+                    ),
+                    CheckRun(
+                        types = listOf(CheckRun.EventType.Completed, CheckRun.EventType.Rerequested),
+                    ),
                     CheckSuite(),
                     Create(),
                     Delete(),
                     Deployment(),
                     DeploymentStatus(),
-                    Discussion(types("created", "edited", "answered")),
+                    Discussion(
+                        types = listOf(Discussion.EventType.Created, Discussion.EventType.Edited, Discussion.EventType.Answered),
+                    ),
                     DiscussionComment(),
                     Fork(),
                     Gollum(),
-                    IssueComment(types("created", "edited", "deleted")),
-                    Issues(types("opened", "edited")),
-                    Label(types("commented", "deleted", "edited")),
+                    IssueComment(
+                        types = listOf(IssueComment.EventType.Created, IssueComment.EventType.Edited, IssueComment.EventType.Deleted),
+                    ),
+                    Issues(
+                        types = listOf(Issues.EventType.Opened, Issues.EventType.Edited),
+                    ),
+                    Label(
+                        types = listOf(Label.EventType.Created, Label.EventType.Deleted, Label.EventType.Edited),
+                    ),
                     MergeGroup(),
-                    Milestone(types("created", "closed")),
+                    Milestone(
+                        types = listOf(Milestone.EventType.Created, Milestone.EventType.Closed),
+                    ),
                     PageBuild(),
-                    Project(types("created", "deleted")),
-                    ProjectCard(types("created", "moved")),
-                    ProjectColumn(types("moved")),
+                    Project(
+                        types = listOf(Project.EventType.Created, Project.EventType.Deleted),
+                    ),
+                    ProjectCard(
+                        types = listOf(ProjectCard.EventType.Created, ProjectCard.EventType.Moved),
+                    ),
+                    ProjectColumn(
+                        types = listOf(ProjectColumn.EventType.Moved),
+                    ),
                     PublicWorkflow(),
                     PullRequest(),
                     PullRequestReview(),
-                    PullRequestReviewComment(types("created", "edited")),
+                    PullRequestReviewComment(
+                        types = listOf(PullRequestReviewComment.EventType.Created, PullRequestReviewComment.EventType.Edited),
+                    ),
                     PullRequestTarget(),
                     Push(),
-                    RegistryPackage(types("published", "updated")),
+                    RegistryPackage(
+                        types = listOf(RegistryPackage.EventType.Published, RegistryPackage.EventType.Updated),
+                    ),
                     Release(types = listOf("published", "unpublished")),
                     RepositoryDispatch(types = listOf("foo", "bar")),
                     Schedule(emptyList()),
-                    Status(types("started")),
+                    Status(
+                        _customArguments = mapOf("types" to listOf("started")),
+                    ),
                     Watch(),
                     WorkflowCall(),
                     WorkflowDispatch(),
-                    WorkflowRun(types("completed", "requested")),
+                    WorkflowRun(
+                        types = listOf(WorkflowRun.EventType.Completed, WorkflowRun.EventType.Requested),
+                    ),
                 )
 
             triggers.triggersToYaml() shouldBe
@@ -147,7 +170,7 @@ class OtherTriggersTest :
                     "gollum" to emptyMap<Any, Any>(),
                     "issue_comment" to mapOf("types" to listOf("created", "edited", "deleted")),
                     "issues" to mapOf("types" to listOf("opened", "edited")),
-                    "label" to mapOf("types" to listOf("commented", "deleted", "edited")),
+                    "label" to mapOf("types" to listOf("created", "deleted", "edited")),
                     "merge_group" to emptyMap<Any, Any>(),
                     "milestone" to mapOf("types" to listOf("created", "closed")),
                     "page_build" to emptyMap<Any, Any>(),

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/triggers/OtherTriggersTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/domain/triggers/OtherTriggersTest.kt
@@ -102,13 +102,23 @@ class OtherTriggersTest :
                     Deployment(),
                     DeploymentStatus(),
                     Discussion(
-                        types = listOf(Discussion.EventType.Created, Discussion.EventType.Edited, Discussion.EventType.Answered),
+                        types =
+                            listOf(
+                                Discussion.EventType.Created,
+                                Discussion.EventType.Edited,
+                                Discussion.EventType.Answered,
+                            ),
                     ),
                     DiscussionComment(),
                     Fork(),
                     Gollum(),
                     IssueComment(
-                        types = listOf(IssueComment.EventType.Created, IssueComment.EventType.Edited, IssueComment.EventType.Deleted),
+                        types =
+                            listOf(
+                                IssueComment.EventType.Created,
+                                IssueComment.EventType.Edited,
+                                IssueComment.EventType.Deleted,
+                            ),
                     ),
                     Issues(
                         types = listOf(Issues.EventType.Opened, Issues.EventType.Edited),
@@ -134,7 +144,11 @@ class OtherTriggersTest :
                     PullRequest(),
                     PullRequestReview(),
                     PullRequestReviewComment(
-                        types = listOf(PullRequestReviewComment.EventType.Created, PullRequestReviewComment.EventType.Edited),
+                        types =
+                            listOf(
+                                PullRequestReviewComment.EventType.Created,
+                                PullRequestReviewComment.EventType.Edited,
+                            ),
                     ),
                     PullRequestTarget(),
                     Push(),


### PR DESCRIPTION
Implements #1784.

Adds a first-class `types` field with a typed sealed `EventType` class to all 18 triggers that support activity types per the [GitHub Actions docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows).

Previously, users had to use `_customArguments = mapOf("types" to ...)` to specify activity types for these triggers.