### PR TITLE
test: remove explicit InferFromClasspath from e2e tests and ignore YAML for Renovate

### DIFF
--- a/.github/workflows/end-to-end-tests.main.kts
+++ b/.github/workflows/end-to-end-tests.main.kts
@@ -30,7 +30,6 @@ import io.github.typesafegithub.workflows.dsl.JobBuilder
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
-import io.github.typesafegithub.workflows.yaml.CheckoutActionVersionSource
 import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 import io.github.typesafegithub.workflows.updates.reportAvailableUpdates
 import java.time.Instant
@@ -55,7 +54,6 @@ workflow(
         env = mapOf(
             "GITHUB_TOKEN" to expr("secrets.GITHUB_TOKEN")
         ),
-        checkoutActionVersion = CheckoutActionVersionSource.InferFromClasspath(),
         additionalSteps = {
             publishToMavenLocal()
             uses(
@@ -318,7 +316,6 @@ workflow(
     ),
     consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
         useLocalBindingsServerAsFallback = true,
-        checkoutActionVersion = CheckoutActionVersionSource.InferFromClasspath(),
         additionalSteps = {
             publishToMavenLocal()
             uses(

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   "automerge": true,
   "ignorePaths": [
     ".github/workflows/end-to-end-tests.yaml",
-    ".github/workflows/end-to-end-tests.main.kts"
+    ".github/workflows/end-to-end-tests.main.kts",
+    ".github/workflows/end-to-end-tests-2nd-workflow.yaml",
   ],
   "packageRules": [
     {


### PR DESCRIPTION
It's the default value in 4.0.0.