### PR TITLE
fix(lib): reword misleading error if no actions/checkout in classpath

### DIFF
--- a/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/ConsistencyCheckJob.kt
+++ b/github-workflows-kt/src/main/kotlin/io/github/typesafegithub/workflows/yaml/ConsistencyCheckJob.kt
@@ -129,7 +129,7 @@ private fun inferCheckoutActionVersionFromClasspath(checkoutActionClassFQN: Stri
             error(
                 "actions/checkout is not found in the classpath! " +
                     "Either add a dependency on it (`@file:DependsOn(\"actions:checkout:<version>\")`), " +
-                    "or don't use CheckoutActionVersionSource.InferFromClasspath()",
+                    "or use another CheckoutActionVersionSource.",
             )
         } as Class<*>
     // It's easier to call the primary constructor, even though it's private, because

--- a/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/IntegrationTest.kt
+++ b/github-workflows-kt/src/test/kotlin/io/github/typesafegithub/workflows/IntegrationTest.kt
@@ -22,6 +22,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
 
 @OptIn(ExperimentalKotlinLogicStep::class)
 @Suppress("LargeClass")
@@ -460,9 +461,7 @@ class IntegrationTest :
                     }
                 }
             }.also {
-                it.message shouldBe "actions/checkout is not found in the classpath! " +
-                    "Either add a dependency on it (`@file:DependsOn(\"actions:checkout:<version>\")`), " +
-                    "or don't use CheckoutActionVersionSource.InferFromClasspath()"
+                it.message shouldStartWith "actions/checkout is not found in the classpath!"
             }
         }
 


### PR DESCRIPTION
Fixes #2387.

The goal is to not mention `InferFromClasspath` as if
it was used explicitly - it's now the default mode.